### PR TITLE
feat: ggmap updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openairmaps
 Title: Create Maps of Air Pollution Data
-Version: 0.8.0.9004
+Version: 0.8.0.9005
 Authors@R: c(
     person("Jack", "Davison", , "jack.davison@ricardo.com", role = c("cre", "aut")),
     person("David", "Carslaw", , "david.carslaw@york.ac.uk", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ These are items associated with the development version of `{openairmaps}`.
 
 * BREAKING: The default arguments of some `polarMap()`-family functions have changed from, e.g., `NULL` to `"free"` or `"fixed"`. (#34)
 
+* BREAKING: Due to changes in `{ggmap}`, all static polar plotting functions now require users to provide their own `ggmap` object. The `zoom` argument has also been removed. This is specifically related to the partnership of Stamen and Stadia which has put the stamen tiles behind an API. See <https://maps.stamen.com/stadia-partnership/> and <https://github.com/dkahle/ggmap/issues/353> for more information. (#52)
+
 ## New features
 
 * Several "limit" arguments can now take one of three options: "fixed" (which forces all markers to share scales), "free" (which allows them to use different scales), or a numeric vector to define the scales. (#34) These arguments and their defaults include:

--- a/R/polar_annulusMap.R
+++ b/R/polar_annulusMap.R
@@ -241,13 +241,12 @@ annulusMap <- function(data,
 #' @export
 annulusMapStatic <- function(data,
                              pollutant = NULL,
+                             ggmap,
                              period = "hour",
                              facet = NULL,
                              limits = "free",
                              latitude = NULL,
                              longitude = NULL,
-                             zoom = 13,
-                             ggmap = NULL,
                              cols = "turbo",
                              alpha = 1,
                              key = FALSE,
@@ -255,6 +254,9 @@ annulusMapStatic <- function(data,
                              d.icon = 150,
                              d.fig = 3,
                              ...) {
+  # check that there is a ggmap
+  check_ggmap(missing(ggmap))
+
   # assume lat/lon
   latlon <- assume_latlon(data = data,
                           latitude = latitude,
@@ -360,16 +362,6 @@ annulusMapStatic <- function(data,
       longitude = longitude,
       split_col = split_col,
       d.fig = d.fig
-    )
-
-  # load ggmap if not provided
-  ggmap <-
-    estimate_ggmap(
-      ggmap = ggmap,
-      data = plots_df,
-      latitude = latitude,
-      longitude = longitude,
-      zoom = zoom
     )
 
   # create static map - deals with basics & facets

--- a/R/polar_diffMap.R
+++ b/R/polar_diffMap.R
@@ -268,13 +268,12 @@ diffMap <- function(before,
 diffMapStatic <- function(before,
                           after,
                           pollutant = NULL,
+                          ggmap,
                           limits = "free",
                           x = "ws",
                           latitude = NULL,
                           longitude = NULL,
                           facet = NULL,
-                          zoom = 13,
-                          ggmap = NULL,
                           cols = c(
                             "#002F70",
                             "#3167BB",
@@ -292,6 +291,9 @@ diffMapStatic <- function(before,
                           d.icon = 150,
                           d.fig = 3,
                           ...) {
+  # check that there is a ggmap
+  check_ggmap(missing(ggmap))
+
   # assume lat/lon
   latlon <- assume_latlon(
     data = before,
@@ -405,16 +407,6 @@ diffMapStatic <- function(before,
       longitude = longitude,
       split_col = split_col,
       d.fig = d.fig
-    )
-
-  # load ggmap if not provided
-  ggmap <-
-    estimate_ggmap(
-      ggmap = ggmap,
-      data = plots_df,
-      latitude = latitude,
-      longitude = longitude,
-      zoom = zoom
     )
 
   # create static map - deals with basics & facets

--- a/R/polar_freqMap.R
+++ b/R/polar_freqMap.R
@@ -280,13 +280,12 @@ freqMap <- function(data,
 #' @export
 freqMapStatic <- function(data,
                           pollutant = NULL,
+                          ggmap,
                           statistic = "mean",
                           breaks = "free",
                           latitude = NULL,
                           longitude = NULL,
                           facet = NULL,
-                          zoom = 13,
-                          ggmap = NULL,
                           cols = "turbo",
                           alpha = 1,
                           key = FALSE,
@@ -294,6 +293,9 @@ freqMapStatic <- function(data,
                           d.icon = 150,
                           d.fig = 3,
                           ...) {
+  # check that there is a ggmap
+  check_ggmap(missing(ggmap))
+
   # assume lat/lon
   latlon <- assume_latlon(data = data,
                           latitude = latitude,
@@ -409,16 +411,6 @@ freqMapStatic <- function(data,
       longitude = longitude,
       split_col = split_col,
       d.fig = d.fig
-    )
-
-  # load ggmap if not provided
-  ggmap <-
-    estimate_ggmap(
-      ggmap = ggmap,
-      data = plots_df,
-      latitude = latitude,
-      longitude = longitude,
-      zoom = zoom
     )
 
   # create static map - deals with basics & facets

--- a/R/polar_percentileMap.R
+++ b/R/polar_percentileMap.R
@@ -242,13 +242,12 @@ percentileMap <- function(data,
 #' @export
 percentileMapStatic <- function(data,
                                 pollutant = NULL,
+                                ggmap,
                                 percentile = c(25, 50, 75, 90, 95),
                                 intervals = "fixed",
                                 latitude = NULL,
                                 longitude = NULL,
                                 facet = NULL,
-                                zoom = 13,
-                                ggmap = NULL,
                                 cols = "turbo",
                                 alpha = 1,
                                 key = FALSE,
@@ -256,6 +255,9 @@ percentileMapStatic <- function(data,
                                 d.icon = 150,
                                 d.fig = 3,
                                 ...) {
+  # check that there is a ggmap
+  check_ggmap(missing(ggmap))
+
   # assume lat/lon
   latlon <- assume_latlon(data = data,
                           latitude = latitude,
@@ -359,16 +361,6 @@ percentileMapStatic <- function(data,
       longitude = longitude,
       split_col = split_col,
       d.fig = d.fig
-    )
-
-  # load ggmap if not provided
-  ggmap <-
-    estimate_ggmap(
-      ggmap = ggmap,
-      data = plots_df,
-      latitude = latitude,
-      longitude = longitude,
-      zoom = zoom
     )
 
   # create static map - deals with basics & facets

--- a/R/polar_polarMap.R
+++ b/R/polar_polarMap.R
@@ -307,14 +307,8 @@ polarMap <- function(data,
 #' @param facet Used for splitting the input data into different panels, passed
 #'   to the `type` argument of [openair::cutData()]. `facet` cannot be used if
 #'   multiple `pollutant` columns have been provided.
-#' @param zoom The zoom level to use for the basemap, passed to
-#'   [ggmap::get_stamenmap()]. Alternatively, the `ggmap` argument can be used
-#'   for more precise control of the basemap.
-#' @param ggmap By default, `openairmaps` will try to estimate an appropriate
-#'   bounding box for the input data and then run [ggmap::get_stamenmap()] to
-#'   import a basemap. The `ggmap` argument allows users to provide their own
-#'   `ggmap` object to override this, which allows for alternative bounding
-#'   boxes, map types and colours.
+#' @param ggmap A `ggmap` object obtained using [ggmap::get_map()] or a similar
+#'   function to use as the basemap.
 #' @param facet.nrow Passed to the `nrow` argument of [ggplot2::facet_wrap()].
 #' @inheritDotParams openair::polarPlot -mydata -pollutant -x -limits -type
 #'   -cols -key -alpha -plot
@@ -327,14 +321,13 @@ polarMap <- function(data,
 #' @export
 polarMapStatic <- function(data,
                            pollutant = NULL,
+                           ggmap,
                            x = "ws",
                            limits = "free",
                            upper = "fixed",
                            latitude = NULL,
                            longitude = NULL,
                            facet = NULL,
-                           zoom = 13,
-                           ggmap = NULL,
                            cols = "turbo",
                            alpha = 1,
                            key = FALSE,
@@ -342,6 +335,9 @@ polarMapStatic <- function(data,
                            d.icon = 150,
                            d.fig = 3,
                            ...) {
+  # check that there is a ggmap
+  check_ggmap(missing(ggmap))
+
   # assume lat/lon
   latlon <- assume_latlon(
     data = data,
@@ -456,16 +452,6 @@ polarMapStatic <- function(data,
       longitude = longitude,
       split_col = split_col,
       d.fig = d.fig
-    )
-
-  # load ggmap if not provided
-  ggmap <-
-    estimate_ggmap(
-      ggmap = ggmap,
-      data = plots_df,
-      latitude = latitude,
-      longitude = longitude,
-      zoom = zoom
     )
 
   # create static map - deals with basics & facets

--- a/R/polar_pollroseMap.R
+++ b/R/polar_pollroseMap.R
@@ -215,13 +215,12 @@ pollroseMap <- function(data,
 #' @export
 pollroseMapStatic <- function(data,
                               pollutant = NULL,
+                              ggmap,
                               statistic = "prop.count",
                               breaks = NULL,
                               facet = NULL,
                               latitude = NULL,
                               longitude = NULL,
-                              zoom = 13,
-                              ggmap = NULL,
                               cols = "turbo",
                               alpha = 1,
                               key = FALSE,
@@ -229,6 +228,9 @@ pollroseMapStatic <- function(data,
                               d.icon = 150,
                               d.fig = 3,
                               ...) {
+  # check that there is a ggmap
+  check_ggmap(missing(ggmap))
+
   # assume lat/lon
   latlon <- assume_latlon(
     data = data,
@@ -298,16 +300,6 @@ pollroseMapStatic <- function(data,
       longitude = longitude,
       split_col = split_col,
       d.fig = d.fig
-    )
-
-  # load ggmap if not provided
-  ggmap <-
-    estimate_ggmap(
-      ggmap = ggmap,
-      data = plots_df,
-      latitude = latitude,
-      longitude = longitude,
-      zoom = zoom
     )
 
   # create static map - deals with basics & facets

--- a/R/polar_windroseMap.R
+++ b/R/polar_windroseMap.R
@@ -203,13 +203,12 @@ windroseMap <- function(data,
 #' @return a `ggplot2` plot with a `ggmap` basemap
 #' @export
 windroseMapStatic <- function(data,
+                              ggmap = NULL,
                               ws.int = 2,
                               breaks = 4,
                               facet = NULL,
                               latitude = NULL,
                               longitude = NULL,
-                              zoom = 13,
-                              ggmap = NULL,
                               cols = "turbo",
                               alpha = 1,
                               key = FALSE,
@@ -217,6 +216,9 @@ windroseMapStatic <- function(data,
                               d.icon = 150,
                               d.fig = 3,
                               ...) {
+  # check that there is a ggmap
+  check_ggmap(missing(ggmap))
+
   # assume lat/lon
   latlon <- assume_latlon(
     data = data,
@@ -288,16 +290,6 @@ windroseMapStatic <- function(data,
       longitude = longitude,
       split_col = split_col,
       d.fig = d.fig
-    )
-
-  # load ggmap if not provided
-  ggmap <-
-    estimate_ggmap(
-      ggmap = ggmap,
-      data = plots_df,
-      latitude = latitude,
-      longitude = longitude,
-      zoom = zoom
     )
 
   # create static map - deals with basics & facets

--- a/R/utils-map.R
+++ b/R/utils-map.R
@@ -603,3 +603,15 @@ check_multipoll <- function(vec, pollutant){
     vec
   }
 }
+
+#' check if ggmap has been provided
+#' @noRd
+check_ggmap <- function(missing) {
+  if (missing) {
+    cli::cli_abort(
+      c("!" = "No {.field ggmap} provided.",
+        "i" = "Please use {.fun ggmap::get_map} or similar to get a tileset."),
+      call = NULL
+    )
+  }
+}

--- a/man/annulusMapStatic.Rd
+++ b/man/annulusMapStatic.Rd
@@ -7,13 +7,12 @@
 annulusMapStatic(
   data,
   pollutant = NULL,
+  ggmap,
   period = "hour",
   facet = NULL,
   limits = "free",
   latitude = NULL,
   longitude = NULL,
-  zoom = 13,
-  ggmap = NULL,
   cols = "turbo",
   alpha = 1,
   key = FALSE,
@@ -32,6 +31,9 @@ longitude.}
 
 \item{pollutant}{The column name(s) of the pollutant(s) to plot. If multiple
 pollutants are specified, they will each form part of a separate panel.}
+
+\item{ggmap}{A \code{ggmap} object obtained using \code{\link[ggmap:get_map]{ggmap::get_map()}} or a similar
+function to use as the basemap.}
 
 \item{period}{This determines the temporal period to consider. Options are
 "hour" (the default, to plot diurnal variations), "season" to plot
@@ -55,16 +57,6 @@ span 0-100.
 \item{latitude, longitude}{The decimal latitude/longitude. If not provided,
 will be automatically inferred from data by looking for a column named
 "lat"/"latitude" or "lon"/"lng"/"long"/"longitude" (case-insensitively).}
-
-\item{zoom}{The zoom level to use for the basemap, passed to
-\code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}}. Alternatively, the \code{ggmap} argument can be used
-for more precise control of the basemap.}
-
-\item{ggmap}{By default, \code{openairmaps} will try to estimate an appropriate
-bounding box for the input data and then run \code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}} to
-import a basemap. The \code{ggmap} argument allows users to provide their own
-\code{ggmap} object to override this, which allows for alternative bounding
-boxes, map types and colours.}
 
 \item{cols}{The colours used for plotting. See \code{\link[openair:openColours]{openair::openColours()}} for
 more information.}

--- a/man/diffMap.Rd
+++ b/man/diffMap.Rd
@@ -277,6 +277,8 @@ regression statistics are used such as \emph{r}. Default is \code{4}.}
     \item{\code{kernel}}{Type of kernel used for the weighting procedure for when
 correlation or regression techniques are used. Only \code{"gaussian"} is
 supported but this may be enhanced in the future.}
+    \item{\code{formula.label}}{When pair-wise statistics such as regression slopes are
+calculated and plotted, should a formula label be displayed?}
     \item{\code{tau}}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}

--- a/man/diffMapStatic.Rd
+++ b/man/diffMapStatic.Rd
@@ -8,13 +8,12 @@ diffMapStatic(
   before,
   after,
   pollutant = NULL,
+  ggmap,
   limits = "free",
   x = "ws",
   latitude = NULL,
   longitude = NULL,
   facet = NULL,
-  zoom = 13,
-  ggmap = NULL,
   cols = c("#002F70", "#3167BB", "#879FDB", "#C8D2F1", "#F6F6F6", "#F4C8C8", "#DA8A8B",
     "#AE4647", "#5F1415"),
   alpha = 1,
@@ -35,6 +34,9 @@ for details of different input requirements.}
 \item{pollutant}{The column name(s) of the pollutant(s) to plot. If multiple
 pollutants are specified, they will each form part of a separate panel.}
 
+\item{ggmap}{A \code{ggmap} object obtained using \code{\link[ggmap:get_map]{ggmap::get_map()}} or a similar
+function to use as the basemap.}
+
 \item{limits}{One of:
 \itemize{
 \item \code{"fixed"} which ensures all of the markers use the same colour scale.
@@ -54,16 +56,6 @@ will be automatically inferred from data by looking for a column named
 \item{facet}{Used for splitting the input data into different panels, passed
 to the \code{type} argument of \code{\link[openair:cutData]{openair::cutData()}}. \code{facet} cannot be used if
 multiple \code{pollutant} columns have been provided.}
-
-\item{zoom}{The zoom level to use for the basemap, passed to
-\code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}}. Alternatively, the \code{ggmap} argument can be used
-for more precise control of the basemap.}
-
-\item{ggmap}{By default, \code{openairmaps} will try to estimate an appropriate
-bounding box for the input data and then run \code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}} to
-import a basemap. The \code{ggmap} argument allows users to provide their own
-\code{ggmap} object to override this, which allows for alternative bounding
-boxes, map types and colours.}
 
 \item{cols}{The colours used for plotting. See \code{\link[openair:openColours]{openair::openColours()}} for
 more information.}
@@ -251,6 +243,8 @@ regression statistics are used such as \emph{r}. Default is \code{4}.}
     \item{\code{kernel}}{Type of kernel used for the weighting procedure for when
 correlation or regression techniques are used. Only \code{"gaussian"} is
 supported but this may be enhanced in the future.}
+    \item{\code{formula.label}}{When pair-wise statistics such as regression slopes are
+calculated and plotted, should a formula label be displayed?}
     \item{\code{tau}}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}

--- a/man/freqMapStatic.Rd
+++ b/man/freqMapStatic.Rd
@@ -7,13 +7,12 @@
 freqMapStatic(
   data,
   pollutant = NULL,
+  ggmap,
   statistic = "mean",
   breaks = "free",
   latitude = NULL,
   longitude = NULL,
   facet = NULL,
-  zoom = 13,
-  ggmap = NULL,
   cols = "turbo",
   alpha = 1,
   key = FALSE,
@@ -32,6 +31,9 @@ longitude.}
 
 \item{pollutant}{The column name(s) of the pollutant(s) to plot. If multiple
 pollutants are specified, they will each form part of a separate panel.}
+
+\item{ggmap}{A \code{ggmap} object obtained using \code{\link[ggmap:get_map]{ggmap::get_map()}} or a similar
+function to use as the basemap.}
 
 \item{statistic}{The statistic that should be applied to each wind
 speed/direction bin. Can be "frequency", "mean", "median", "max" (maximum),
@@ -64,16 +66,6 @@ will be automatically inferred from data by looking for a column named
 \item{facet}{Used for splitting the input data into different panels, passed
 to the \code{type} argument of \code{\link[openair:cutData]{openair::cutData()}}. \code{facet} cannot be used if
 multiple \code{pollutant} columns have been provided.}
-
-\item{zoom}{The zoom level to use for the basemap, passed to
-\code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}}. Alternatively, the \code{ggmap} argument can be used
-for more precise control of the basemap.}
-
-\item{ggmap}{By default, \code{openairmaps} will try to estimate an appropriate
-bounding box for the input data and then run \code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}} to
-import a basemap. The \code{ggmap} argument allows users to provide their own
-\code{ggmap} object to override this, which allows for alternative bounding
-boxes, map types and colours.}
 
 \item{cols}{The colours used for plotting. See \code{\link[openair:openColours]{openair::openColours()}} for
 more information.}

--- a/man/networkMap.Rd
+++ b/man/networkMap.Rd
@@ -15,9 +15,21 @@ networkMap(
 )
 }
 \arguments{
-\item{source}{One or more sources of meta data. Can be \code{aurn}, \code{saqn} (or
-\code{saqd}), \code{aqe}, \code{waqn}, \code{ni}, \code{local} (or \code{lmam}), \code{kcl} or \code{europe}; upper
-or lower case.}
+\item{source}{One or more air quality networks for which data is available
+through openair. Available networks include:
+\itemize{
+\item \code{"aurn"},  The UK Automatic Urban and Rural Network.
+\item \code{"aqe"},  The Air Quality England Network.
+\item \code{"saqn"},  The Scottish Air Quality Network.
+\item \code{"waqn"},  The Welsh Air Quality Network.
+\item \code{"ni"},  The Northern Ireland Air Quality Network.
+\item \code{"local"},  Locally managed air quality networks in England.
+\item \code{"kcl"}, King's College London networks.
+\item \code{"europe"}, European AirBase/e-reporting data.
+There are two additional options provided for convenience:
+\item \code{"ukaq"} will return metadata for all networks for which data is imported by \code{\link[openair:importUKAQ]{importUKAQ()}} (i.e., AURN, AQE, SAQN, WAQN, NI, and the local networks).
+\item \code{"all"} will import all available metadata (i.e., \code{"ukaq"} plus \code{"kcl"} and \code{"europe"}).
+}}
 
 \item{control}{Option to add a "layer control" menu to allow readers to
 select between different site types. Can choose between effectively any

--- a/man/percentileMapStatic.Rd
+++ b/man/percentileMapStatic.Rd
@@ -7,13 +7,12 @@
 percentileMapStatic(
   data,
   pollutant = NULL,
+  ggmap,
   percentile = c(25, 50, 75, 90, 95),
   intervals = "fixed",
   latitude = NULL,
   longitude = NULL,
   facet = NULL,
-  zoom = 13,
-  ggmap = NULL,
   cols = "turbo",
   alpha = 1,
   key = FALSE,
@@ -33,6 +32,9 @@ longitude.}
 \item{pollutant}{The column name(s) of the pollutant(s) to plot. If multiple
 pollutants are specified, they will each form part of a separate panel.}
 
+\item{ggmap}{A \code{ggmap} object obtained using \code{\link[ggmap:get_map]{ggmap::get_map()}} or a similar
+function to use as the basemap.}
+
 \item{percentile}{The percentile value(s) to plot. Must be between 0–100. If
 \code{percentile = NA} then only a mean line will be shown.}
 
@@ -50,16 +52,6 @@ will be automatically inferred from data by looking for a column named
 \item{facet}{Used for splitting the input data into different panels, passed
 to the \code{type} argument of \code{\link[openair:cutData]{openair::cutData()}}. \code{facet} cannot be used if
 multiple \code{pollutant} columns have been provided.}
-
-\item{zoom}{The zoom level to use for the basemap, passed to
-\code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}}. Alternatively, the \code{ggmap} argument can be used
-for more precise control of the basemap.}
-
-\item{ggmap}{By default, \code{openairmaps} will try to estimate an appropriate
-bounding box for the input data and then run \code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}} to
-import a basemap. The \code{ggmap} argument allows users to provide their own
-\code{ggmap} object to override this, which allows for alternative bounding
-boxes, map types and colours.}
 
 \item{cols}{The colours used for plotting. See \code{\link[openair:openColours]{openair::openColours()}} for
 more information.}

--- a/man/polarMap.Rd
+++ b/man/polarMap.Rd
@@ -287,6 +287,8 @@ regression statistics are used such as \emph{r}. Default is \code{4}.}
     \item{\code{kernel}}{Type of kernel used for the weighting procedure for when
 correlation or regression techniques are used. Only \code{"gaussian"} is
 supported but this may be enhanced in the future.}
+    \item{\code{formula.label}}{When pair-wise statistics such as regression slopes are
+calculated and plotted, should a formula label be displayed?}
     \item{\code{tau}}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}

--- a/man/polarMapStatic.Rd
+++ b/man/polarMapStatic.Rd
@@ -7,14 +7,13 @@
 polarMapStatic(
   data,
   pollutant = NULL,
+  ggmap,
   x = "ws",
   limits = "free",
   upper = "fixed",
   latitude = NULL,
   longitude = NULL,
   facet = NULL,
-  zoom = 13,
-  ggmap = NULL,
   cols = "turbo",
   alpha = 1,
   key = FALSE,
@@ -33,6 +32,9 @@ longitude.}
 
 \item{pollutant}{The column name(s) of the pollutant(s) to plot. If multiple
 pollutants are specified, they will each form part of a separate panel.}
+
+\item{ggmap}{A \code{ggmap} object obtained using \code{\link[ggmap:get_map]{ggmap::get_map()}} or a similar
+function to use as the basemap.}
 
 \item{x}{The radial axis variable to plot.}
 
@@ -60,16 +62,6 @@ will be automatically inferred from data by looking for a column named
 \item{facet}{Used for splitting the input data into different panels, passed
 to the \code{type} argument of \code{\link[openair:cutData]{openair::cutData()}}. \code{facet} cannot be used if
 multiple \code{pollutant} columns have been provided.}
-
-\item{zoom}{The zoom level to use for the basemap, passed to
-\code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}}. Alternatively, the \code{ggmap} argument can be used
-for more precise control of the basemap.}
-
-\item{ggmap}{By default, \code{openairmaps} will try to estimate an appropriate
-bounding box for the input data and then run \code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}} to
-import a basemap. The \code{ggmap} argument allows users to provide their own
-\code{ggmap} object to override this, which allows for alternative bounding
-boxes, map types and colours.}
 
 \item{cols}{The colours used for plotting. See \code{\link[openair:openColours]{openair::openColours()}} for
 more information.}
@@ -268,6 +260,8 @@ regression statistics are used such as \emph{r}. Default is \code{4}.}
     \item{\code{kernel}}{Type of kernel used for the weighting procedure for when
 correlation or regression techniques are used. Only \code{"gaussian"} is
 supported but this may be enhanced in the future.}
+    \item{\code{formula.label}}{When pair-wise statistics such as regression slopes are
+calculated and plotted, should a formula label be displayed?}
     \item{\code{tau}}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}

--- a/man/polar_data.Rd
+++ b/man/polar_data.Rd
@@ -20,7 +20,7 @@ Data frame with example data from four sites in London in 2009.
 }
 \source{
 \code{polar_data} was compiled from data using the
-\code{\link[openair:importAURN]{openair::importAURN()}} function from the \code{openair} package with
+\code{\link[openair:importUKAQ-wrapper]{openair::importAURN()}} function from the \code{openair} package with
 meteorological data from the \code{worldmet} package.
 }
 \description{

--- a/man/pollroseMapStatic.Rd
+++ b/man/pollroseMapStatic.Rd
@@ -7,13 +7,12 @@
 pollroseMapStatic(
   data,
   pollutant = NULL,
+  ggmap,
   statistic = "prop.count",
   breaks = NULL,
   facet = NULL,
   latitude = NULL,
   longitude = NULL,
-  zoom = 13,
-  ggmap = NULL,
   cols = "turbo",
   alpha = 1,
   key = FALSE,
@@ -32,6 +31,9 @@ longitude.}
 
 \item{pollutant}{The column name(s) of the pollutant(s) to plot. If multiple
 pollutants are specified, they will each form part of a separate panel.}
+
+\item{ggmap}{A \code{ggmap} object obtained using \code{\link[ggmap:get_map]{ggmap::get_map()}} or a similar
+function to use as the basemap.}
 
 \item{statistic}{The \code{statistic} to be applied to each data bin in the
 plot. Options currently include "prop.count", "prop.mean" and
@@ -55,16 +57,6 @@ multiple \code{pollutant} columns have been provided.}
 \item{latitude, longitude}{The decimal latitude/longitude. If not provided,
 will be automatically inferred from data by looking for a column named
 "lat"/"latitude" or "lon"/"lng"/"long"/"longitude" (case-insensitively).}
-
-\item{zoom}{The zoom level to use for the basemap, passed to
-\code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}}. Alternatively, the \code{ggmap} argument can be used
-for more precise control of the basemap.}
-
-\item{ggmap}{By default, \code{openairmaps} will try to estimate an appropriate
-bounding box for the input data and then run \code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}} to
-import a basemap. The \code{ggmap} argument allows users to provide their own
-\code{ggmap} object to override this, which allows for alternative bounding
-boxes, map types and colours.}
 
 \item{cols}{The colours used for plotting. See \code{\link[openair:openColours]{openair::openColours()}} for
 more information.}

--- a/man/searchNetwork.Rd
+++ b/man/searchNetwork.Rd
@@ -20,15 +20,26 @@ searchNetwork(
 \arguments{
 \item{lat, lng}{The latitude and longitude for the location of interest.}
 
-\item{source}{One or more sources of meta data. Can be \code{aurn}, \code{saqn} (or
-\code{saqd}), \code{aqe}, \code{waqn}, \code{ni}, \code{local} (or \code{lmam}), \code{kcl} or \code{europe}; upper
-or lower case.}
+\item{source}{One or more air quality networks for which data is available
+through openair. Available networks include:
+\itemize{
+\item \code{"aurn"},  The UK Automatic Urban and Rural Network.
+\item \code{"aqe"},  The Air Quality England Network.
+\item \code{"saqn"},  The Scottish Air Quality Network.
+\item \code{"waqn"},  The Welsh Air Quality Network.
+\item \code{"ni"},  The Northern Ireland Air Quality Network.
+\item \code{"local"},  Locally managed air quality networks in England.
+\item \code{"kcl"}, King's College London networks.
+\item \code{"europe"}, European AirBase/e-reporting data.
+There are two additional options provided for convenience:
+\item \code{"ukaq"} will return metadata for all networks for which data is imported by \code{\link[openair:importUKAQ]{importUKAQ()}} (i.e., AURN, AQE, SAQN, WAQN, NI, and the local networks).
+\item \code{"all"} will import all available metadata (i.e., \code{"ukaq"} plus \code{"kcl"} and \code{"europe"}).
+}}
 
 \item{year}{If a single year is selected, only sites that were open at some
 point in that year are returned. If \code{all = TRUE} only sites that
 measured a particular pollutant in that year are returned. Year can also be
-a sequence e.g. \code{year = 2010:2020} or of length 2 e.g. \code{year =
-  c(2010, 2020)}, which will return only sites that were open over the
+a sequence e.g. \code{year = 2010:2020} or of length 2 e.g. \code{year = c(2010, 2020)}, which will return only sites that were open over the
 duration. Note that \code{year} is ignored when the \code{source} is either
 \code{"kcl"} or \code{"europe"}.}
 

--- a/man/traj_data.Rd
+++ b/man/traj_data.Rd
@@ -29,7 +29,7 @@ A data frame with 53940 rows and 10 variables:
 \source{
 \code{traj_data} was compiled from data using the \code{\link[openair:importTraj]{openair::importTraj()}}
 function from the \code{openair} package with air quality data from
-\code{\link[openair:importAURN]{openair::importAURN()}} function.
+\code{\link[openair:importUKAQ-wrapper]{openair::importAURN()}} function.
 }
 \usage{
 traj_data

--- a/man/windroseMapStatic.Rd
+++ b/man/windroseMapStatic.Rd
@@ -6,13 +6,12 @@
 \usage{
 windroseMapStatic(
   data,
+  ggmap = NULL,
   ws.int = 2,
   breaks = 4,
   facet = NULL,
   latitude = NULL,
   longitude = NULL,
-  zoom = 13,
-  ggmap = NULL,
   cols = "turbo",
   alpha = 1,
   key = FALSE,
@@ -28,6 +27,9 @@ directional analysis marker, which includes wind speed (\code{ws}), wind
 direction (\code{wd}), and the column representing the concentration of a
 pollutant. In addition, \code{data} must include a decimal latitude and
 longitude.}
+
+\item{ggmap}{A \code{ggmap} object obtained using \code{\link[ggmap:get_map]{ggmap::get_map()}} or a similar
+function to use as the basemap.}
 
 \item{ws.int}{The wind speed interval. Default is 2 m/s but for low met masts
 with low mean wind speeds a value of 1 or 0.5 m/s may be better.}
@@ -45,16 +47,6 @@ multiple \code{pollutant} columns have been provided.}
 \item{latitude, longitude}{The decimal latitude/longitude. If not provided,
 will be automatically inferred from data by looking for a column named
 "lat"/"latitude" or "lon"/"lng"/"long"/"longitude" (case-insensitively).}
-
-\item{zoom}{The zoom level to use for the basemap, passed to
-\code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}}. Alternatively, the \code{ggmap} argument can be used
-for more precise control of the basemap.}
-
-\item{ggmap}{By default, \code{openairmaps} will try to estimate an appropriate
-bounding box for the input data and then run \code{\link[ggmap:get_stamenmap]{ggmap::get_stamenmap()}} to
-import a basemap. The \code{ggmap} argument allows users to provide their own
-\code{ggmap} object to override this, which allows for alternative bounding
-boxes, map types and colours.}
 
 \item{cols}{The colours used for plotting. See \code{\link[openair:openColours]{openair::openColours()}} for
 more information.}

--- a/tests/testthat/test-polar_annulusMap.R
+++ b/tests/testthat/test-polar_annulusMap.R
@@ -15,16 +15,3 @@ test_that("annulus map works in an advanced way", {
     limits = c(0, 200)
   ))
 })
-
-test_that("static annulus map works with two pollutants", {
-  expect_no_error(annulusMapStatic(polar_data, c("nox", "pm2.5")))
-})
-
-test_that("static annulus map works in an advanced way", {
-  expect_no_error(annulusMapStatic(
-    polar_data,
-    "nox",
-    facet = "weekend",
-    limits = c(0, 200)
-  ))
-})

--- a/tests/testthat/test-polar_freqMap.R
+++ b/tests/testthat/test-polar_freqMap.R
@@ -15,16 +15,3 @@ test_that("freq map works in an advanced way", {
     breaks = c(0, 1, 5, 7, 10)
   ))
 })
-
-test_that("static freq map works with two pollutants", {
-  expect_no_error(freqMapStatic(polar_data, c("nox", "pm2.5")))
-})
-
-test_that("static freq map works in an advanced way", {
-  expect_no_error(freqMapStatic(
-    polar_data,
-    "nox",
-    facet = "weekend",
-    breaks = c(0, 1, 5, 7, 10)
-  ))
-})

--- a/tests/testthat/test-polar_percentileMap.R
+++ b/tests/testthat/test-polar_percentileMap.R
@@ -20,20 +20,3 @@
 #   ))
 # })
 #
-# test_that("static percentile map works in a simple way", {
-#   expect_no_error(percentileMapStatic(polar_data, "nox"))
-# })
-#
-# test_that("static percentile map works with two pollutants", {
-#   expect_no_error(percentileMapStatic(polar_data, c("nox", "pm2.5"), intervals = "free"))
-# })
-#
-# test_that("static percentile map works in an advanced way", {
-#   expect_no_error(percentileMapStatic(
-#     polar_data,
-#     "nox",
-#     facet = "weekend",
-#     percentile = c(25, 50)
-#   ))
-# })
-#

--- a/tests/testthat/test-polar_polarMap.R
+++ b/tests/testthat/test-polar_polarMap.R
@@ -15,16 +15,3 @@ test_that("polar map works in an advanced way", {
     limits = c(0, 200)
   ))
 })
-
-test_that("static polar map works with two pollutants", {
-  expect_no_error(polarMapStatic(polar_data, c("nox", "pm2.5")))
-})
-
-test_that("static polar map works in an advanced way", {
-  expect_no_error(polarMapStatic(
-    polar_data,
-    "nox",
-    facet = "weekend",
-    limits = c(0, 200)
-  ))
-})

--- a/tests/testthat/test-polar_pollroseMap.R
+++ b/tests/testthat/test-polar_pollroseMap.R
@@ -15,16 +15,3 @@ test_that("pollutionrose map works in an advanced way", {
     breaks = 10
   ))
 })
-
-test_that("static pollutionrose map works with two pollutants", {
-  expect_no_error(pollroseMapStatic(polar_data, c("nox", "pm2.5")))
-})
-
-test_that("static pollutionrose map works in an advanced way", {
-  expect_no_error(pollroseMapStatic(
-    polar_data,
-    "nox",
-    facet = "weekend",
-    breaks = 10
-  ))
-})

--- a/tests/testthat/test-polar_windroseMap.R
+++ b/tests/testthat/test-polar_windroseMap.R
@@ -10,11 +10,3 @@ test_that("windrose map works in an advanced way", {
     ws.int = 10, breaks = 4
   ))
 })
-
-test_that("static windrose map works in an advanced way", {
-  expect_no_error(windroseMapStatic(
-    polar_data,
-    facet = "weekend",
-    ws.int = 10, breaks = 4
-  ))
-})


### PR DESCRIPTION
Due to changes in `{ggmap}`, all static polar plotting functions now require users to provide their own `ggmap` object. The `zoom` argument has also been removed. This is specifically related to the partnership of Stamen and Stadia which has put the stamen tiles behind an API. See <https://maps.stamen.com/stadia-partnership/> and <https://github.com/dkahle/ggmap/issues/353> for more information.

Closes #52.