### PR TITLE
Add Shiny Examples (and fix addTrajPath layerId)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Popups for the `polarMap()` family will now be near the top of the plot rather than the centre. This will obscure less of the plot itself while the marker is visible.
 
+* Two examples of the use of `{openairmaps}` with `{shiny}` have been added to the package. Run `shiny::runExample(package = "openairmaps")` to view these.
+
 # openairmaps 0.8.1
 
 This is a minor release of `{openairmaps}`, released mainly to fix an issue with `{ggmap}` but also adding some new functionality for polar marker maps.

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,12 @@
 
 * Two examples of the use of `{openairmaps}` with `{shiny}` have been added to the package. Run `shiny::runExample(package = "openairmaps")` to view these.
 
+## Bug fixes
+
+* The `addTrajPaths()` `layerId` argument is now implemented in a sensible way to ensure each geometry has a unique `layerId` and can therefore be interacted with in a `{shiny}` context. 
+
+    * `layerId` is now the base on which the actual layerId is built, with each real layerId in the form BASE-LN-PN where LN is the line number and PN is the point number. For example, if `layerId = "traj"`, the first point of the first line has the ID `"traj-1-1"`, the second point of the first line has ID `"traj-1-2"`, the first point of the second line has ID `"traj-2-1"`, and so on.
+
 # openairmaps 0.8.1
 
 This is a minor release of `{openairmaps}`, released mainly to fix an issue with `{ggmap}` but also adding some new functionality for polar marker maps.

--- a/R/addPolarMarkers.R
+++ b/R/addPolarMarkers.R
@@ -38,6 +38,8 @@
 #' @param ... Other arguments for the plotting function (e.g. `period` for
 #'   [openair::polarAnnulus()]).
 #' @return A leaflet object.
+#' @seealso `shiny::runExample(package = "openairmaps")` to see examples of this
+#'   function used in a [shiny::shinyApp()]
 #' @describeIn addPolarMarkers Add any one-table polar marker (e.g.,
 #'   [openair::polarPlot()])
 #' @export

--- a/R/addTrajPaths.R
+++ b/R/addTrajPaths.R
@@ -45,6 +45,8 @@
 #'   `opacity` controls the opacity of the lines and `fillOpacity` the opacity
 #'   of the markers.
 #' @return A leaflet object.
+#' @seealso `shiny::runExample(package = "openairmaps")` to see examples of this
+#'   function used in a [shiny::shinyApp()]
 #' @export
 #'
 #' @examples

--- a/inst/examples-shiny/01_polarmap.R
+++ b/inst/examples-shiny/01_polarmap.R
@@ -1,0 +1,63 @@
+
+library(shiny)
+library(bslib)
+library(openairmaps)
+
+# get list of sites in data
+sites <- unique(polar_data$site)
+
+# create initial map
+map <- leaflet::leaflet() %>%
+  leaflet::addTiles() %>%
+  leaflet::setView(lng = -0.213492,
+                   lat = 51.49548,
+                   zoom = 13)
+
+# create user interface
+ui <-
+  bslib::page_sidebar(
+    sidebar = bslib::sidebar(
+      shiny::selectInput(
+        "pollutant",
+        "Pollutant",
+        choices = c("nox", "no2", "pm2.5", "pm10")
+      ),
+      shiny::selectInput(
+        "sites",
+        "Sites",
+        choices = sites,
+        selected = sites,
+        multiple = TRUE
+      ),
+      bslib::input_task_button("button", "Plot")
+    ),
+    leaflet::leafletOutput("map")
+  )
+
+# define server-side functionality
+server <- function(input, output, session) {
+  output$map <- leaflet::renderLeaflet(map)
+
+  observeEvent(input$button, {
+    leaflet::leafletProxy("map") %>%
+      leaflet::removeMarker(layerId = sites)
+
+    for (i in seq_along(input$sites)) {
+      thedata <- polar_data[polar_data$site == input$sites[i], ]
+
+      leaflet::leafletProxy("map") %>%
+        addPolarMarkers(
+          data = thedata,
+          pollutant = input$pollutant,
+          layerId = input$sites[i],
+          cols = "turbo",
+          lng = "lon",
+          lat = "lat"
+        )
+    }
+  })
+
+}
+
+# run app
+shinyApp(ui, server)

--- a/inst/examples-shiny/02_trajmap.R
+++ b/inst/examples-shiny/02_trajmap.R
@@ -12,7 +12,7 @@ lcombos <- paste("traj", combos$Var1, sep = "-")
 
 # create initial map
 map <- leaflet::leaflet() %>%
-  leaflet::addTiles() %>%
+  leaflet::addProviderTiles(provider = leaflet::providers$CartoDB.Voyager) %>%
   leaflet::setView(lng = -10, lat = 60, zoom = 4)
 
 # create user interface

--- a/inst/examples-shiny/02_trajmap.R
+++ b/inst/examples-shiny/02_trajmap.R
@@ -4,6 +4,9 @@ library(bslib)
 library(openairmaps)
 
 dates <- unique(traj_data$date)
+combos <- expand.grid(1:100, 1:100)
+pcombos <- paste("traj", combos$Var1, combos$Var2, sep = "-")
+lcombos <- paste("traj", combos$Var1, sep = "-")
 
 # create initial map
 map <- leaflet::leaflet() %>%
@@ -35,18 +38,15 @@ server <- function(input, output, session) {
 
   observeEvent(input$slider, {
     leaflet::leafletProxy("map") %>%
-      leaflet::removeMarker(as.character(dates)) %>%
-      leaflet::removeShape(as.character(dates))
+      leaflet::removeMarker(pcombos) %>%
+      leaflet::removeShape(lcombos)
 
     thedates <-
       dates[dates > min(input$slider) & dates < max(input$slider)]
 
-    for (i in seq_along(thedates)) {
-      thedata <- traj_data[traj_data$date == thedates[i], ]
-      leaflet::leafletProxy("map") %>%
-        addTrajPaths(layerId = as.character(thedates[i]),
-                     data = thedata)
-    }
+    thedata <- traj_data[traj_data$date %in% thedates, ]
+    leaflet::leafletProxy("map") %>%
+      addTrajPaths(layerId = "traj", data = thedata)
   })
 }
 

--- a/inst/examples-shiny/02_trajmap.R
+++ b/inst/examples-shiny/02_trajmap.R
@@ -1,0 +1,54 @@
+
+library(shiny)
+library(bslib)
+library(openairmaps)
+
+dates <- unique(traj_data$date)
+
+# create initial map
+map <- leaflet::leaflet() %>%
+  leaflet::addTiles() %>%
+  leaflet::setView(lng = -10, lat = 60, zoom = 4)
+
+# create user interface
+ui <-
+  bslib::page_fillable(bslib::card(
+    bslib::card_header("Trajectory Map"),
+    bslib::card_body(leaflet::leafletOutput("map")),
+    bslib::card_footer(
+      shiny::sliderInput(
+        timezone = "GMT",
+        width = "100%",
+        timeFormat = "%F",
+        "slider",
+        "Date",
+        min = min(dates),
+        max = max(dates),
+        value = range(dates)
+      )
+    )
+  ))
+
+# define server-side functionality
+server <- function(input, output, session) {
+  output$map <- leaflet::renderLeaflet(map)
+
+  observeEvent(input$slider, {
+    leaflet::leafletProxy("map") %>%
+      leaflet::removeMarker(as.character(dates)) %>%
+      leaflet::removeShape(as.character(dates))
+
+    thedates <-
+      dates[dates > min(input$slider) & dates < max(input$slider)]
+
+    for (i in seq_along(thedates)) {
+      thedata <- traj_data[traj_data$date == thedates[i], ]
+      leaflet::leafletProxy("map") %>%
+        addTrajPaths(layerId = as.character(thedates[i]),
+                     data = thedata)
+    }
+  })
+}
+
+# run app
+shinyApp(ui, server)

--- a/inst/examples-shiny/02_trajmap.R
+++ b/inst/examples-shiny/02_trajmap.R
@@ -4,6 +4,8 @@ library(bslib)
 library(openairmaps)
 
 dates <- unique(traj_data$date)
+
+# get combos for layerId removal
 combos <- expand.grid(1:100, 1:100)
 pcombos <- paste("traj", combos$Var1, combos$Var2, sep = "-")
 lcombos <- paste("traj", combos$Var1, sep = "-")
@@ -42,7 +44,7 @@ server <- function(input, output, session) {
       leaflet::removeShape(lcombos)
 
     thedates <-
-      dates[dates > min(input$slider) & dates < max(input$slider)]
+      dates[dates >= min(input$slider) & dates <= max(input$slider)]
 
     thedata <- traj_data[traj_data$date %in% thedates, ]
     leaflet::leafletProxy("map") %>%

--- a/man/addPolarMarkers.Rd
+++ b/man/addPolarMarkers.Rd
@@ -166,3 +166,7 @@ leaflet(data = polar_data) \%>\%
   )
 }
 }
+\seealso{
+\code{shiny::runExample(package = "openairmaps")} to see examples of this
+function used in a \code{\link[shiny:shinyApp]{shiny::shinyApp()}}
+}

--- a/man/addTrajPaths.Rd
+++ b/man/addTrajPaths.Rd
@@ -96,3 +96,7 @@ for (i in seq(length(unique(traj_data$date)))) {
 map
 }
 }
+\seealso{
+\code{shiny::runExample(package = "openairmaps")} to see examples of this
+function used in a \code{\link[shiny:shinyApp]{shiny::shinyApp()}}
+}

--- a/man/addTrajPaths.Rd
+++ b/man/addTrajPaths.Rd
@@ -22,7 +22,10 @@ addTrajPaths(
 
 \item{lat}{The decimal latitude.}
 
-\item{layerId}{The layer id.}
+\item{layerId}{The base string for the layer id. The actual layer IDs will be
+in the format "layerId-linenum" for lines and "layerId_linenum-pointnum"
+for points. For example, the first point of the first trajectory path will
+be "layerId-1-1".}
 
 \item{group}{the name of the group the newly created layers should belong to
 (for \code{\link[leaflet:remove]{leaflet::clearGroup()}} and \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}} purposes).


### PR DESCRIPTION
This adds two Shiny Examples to `{openairmaps}`, to be accessed via <https://shiny.posit.co/r/reference/shiny/latest/runexample>.

Also fixes `addTrajPath()`'s `layerId` arg to actually work!

Fixes #60 