### PR TITLE
Extra options for the position and title of legends and layer control menus

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@ README_cache
 ^pkgdown$
 ^CODE_OF_CONDUCT\.md$
 ^codecov\.yml$
+man/figures/

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * BREAKING: The `names` and `cols` arguments of `buildPopup()` have been coalesced into a single `columns` argument for less verbose function usage.
 
+* BREAKING: The `collapse.control` argument has been renamed to `control.collapsed` and the `draw.legend` argument to `legend`. This is to allow these options to sit more nicely with their new argument family members - `legend.title`, `legend.title.autotext`, `legend.position`, and so on.
+
 ## New features
 
 * The `polarMapStatic()` family of functions have been combined with the `polarMap()` family, with static maps available to be accessed using the `static` argument. The `polarMapStatic()` family are therefore deprecated, and will later be removed from `{openairmaps}`. The justification for this is as follows:
@@ -21,6 +23,8 @@
     * Combining these functions has reduced repetition in the source code of `{openairmaps}`, reducing the likelihood of oversights and bugs, and allowing for more rapid development.
 
 * The `crs` argument has been added to the `polarMap()` and `polarMapStatic()` families and to `searchNetwork()`. This argument allows for users to specify that their data is using an alternative coordinate system to the standard longitude/latitude (e.g., the British National Grid CRS). Alternate CRS will be re-projected to longitude/latitude for plotting as this is expected by `{leaflet}` / `{ggspatial}`.
+
+* Users now have greater control over the positions of legends and layer control menus, and the titles of legends, throughout `{openairmaps}` functions, including the `polarMap()` family, `trajMap()` family, and `networkMap()`.
 
 * Popups for the dynamic `polarMap()` family will now be near the top of the plot rather than the centre. This will obscure less of the plot itself while the marker is visible.
 

--- a/R/network_networkMap.R
+++ b/R/network_networkMap.R
@@ -62,7 +62,7 @@
 #'
 #' @param cluster *Cluster markers together when zoomed out?*
 #'
-#'  *default:* `FALSE`
+#'  *default:* `TRUE`
 #'
 #'   When `cluster = TRUE`, markers are clustered together. This may be useful
 #'   for sources like "kcl" where there are many markers very close together.
@@ -83,14 +83,14 @@
 #'
 #' @param legend *Draw a shared legend?*
 #'
-#'  *default:* `TRUE` | *scope:* dynamic & static
+#'  *default:* `TRUE`
 #'
 #'   When multiple `source`s are defined, should a shared legend be created at
 #'   the side of the map?
 #'
 #' @param collapse.control *Show the layer control as a collapsed?*
 #'
-#'  *default:* `FALSE` | *scope:* dynamic
+#'  *default:* `FALSE`
 #'
 #'   Should the "layer control" interface be collapsed? If `TRUE`, users will
 #'   have to hover over an icon to view the options.

--- a/R/network_networkMap.R
+++ b/R/network_networkMap.R
@@ -81,7 +81,7 @@
 #'   own using a named vector (e.g., `c("Default" = "OpenStreetMap", "Satellite"
 #'   = "Esri.WorldImagery")`)
 #'
-#' @param draw.legend *Draw a shared legend?*
+#' @param legend *Draw a shared legend?*
 #'
 #'  *default:* `TRUE` | *scope:* dynamic & static
 #'
@@ -119,7 +119,7 @@ networkMap <-
              "Default" = "OpenStreetMap",
              "Satellite" = "Esri.WorldImagery"
            ),
-           draw.legend = TRUE,
+           legend = TRUE,
            collapse.control = FALSE) {
     # if year isn't provided, use current year
     if (is.null(year)) {
@@ -364,7 +364,7 @@ networkMap <-
     }
 
     # multiple sources - add legend
-    if (length(source) > 1 & draw.legend) {
+    if (length(source) > 1 & legend) {
       map <-
         leaflet::addLegend(
           map,

--- a/R/network_networkMap.R
+++ b/R/network_networkMap.R
@@ -88,12 +88,28 @@
 #'   When multiple `source`s are defined, should a shared legend be created at
 #'   the side of the map?
 #'
-#' @param collapse.control *Show the layer control as a collapsed?*
+#' @param legend.position *Position of the legend*
+#'
+#'  *default:* `"topright"`
+#'
+#'   Where should the shared legend be placed? One of "topleft", "topright",
+#'   "bottomleft" or "bottomright". Passed to the `position` argument of
+#'   [leaflet::addLayersControl()].
+#'
+#' @param control.collapsed *Show the layer control as a collapsed?*
 #'
 #'  *default:* `FALSE`
 #'
 #'   Should the "layer control" interface be collapsed? If `TRUE`, users will
 #'   have to hover over an icon to view the options.
+#'
+#' @param control.position *Position of the layer control menu*
+#'
+#'  *default:* `"topright"`
+#'
+#'   Where should the "layer control" interface be placed? One of "topleft",
+#'   "topright", "bottomleft" or "bottomright". Passed to the `position`
+#'   argument of [leaflet::addLayersControl()].
 #'
 #' @returns A leaflet object.
 #' @export
@@ -120,7 +136,9 @@ networkMap <-
              "Satellite" = "Esri.WorldImagery"
            ),
            legend = TRUE,
-           collapse.control = FALSE) {
+           legend.position = "topright",
+           control.collapsed = FALSE,
+           control.position = "topright") {
     # if year isn't provided, use current year
     if (is.null(year)) {
       year <- lubridate::year(Sys.Date())
@@ -218,6 +236,7 @@ networkMap <-
 
     # sort out control
     if (!is.null(control)) {
+      control.position <- check_legendposition(control.position, static = FALSE)
       if (!control %in% names(meta)) {
         trycols <- names(meta)[!names(meta) %in%
           c(
@@ -299,7 +318,8 @@ networkMap <-
           map <-
             leaflet::addLayersControl(
               map,
-              options = leaflet::layersControlOptions(collapsed = collapse.control, autoZIndex = FALSE),
+              position = control.position,
+              options = leaflet::layersControlOptions(collapsed = control.collapsed, autoZIndex = FALSE),
               baseGroups = quickTextHTML(sort(control_vars)),
               overlayGroups = names(provider)
             ) %>%
@@ -308,7 +328,8 @@ networkMap <-
           map <-
             leaflet::addLayersControl(
               map,
-              options = leaflet::layersControlOptions(collapsed = collapse.control, autoZIndex = FALSE),
+              position = control.position,
+              options = leaflet::layersControlOptions(collapsed = control.collapsed, autoZIndex = FALSE),
               baseGroups = quickTextHTML(sort(control_vars))
             )
         }
@@ -317,7 +338,8 @@ networkMap <-
           map <-
             leaflet::addLayersControl(
               map,
-              options = leaflet::layersControlOptions(collapsed = collapse.control, autoZIndex = FALSE),
+              position = control.position,
+              options = leaflet::layersControlOptions(collapsed = control.collapsed, autoZIndex = FALSE),
               overlayGroups = quickTextHTML(sort(control_vars)),
               baseGroups = names(provider)
             ) %>%
@@ -326,7 +348,8 @@ networkMap <-
           map <-
             leaflet::addLayersControl(
               map,
-              options = leaflet::layersControlOptions(collapsed = collapse.control, autoZIndex = FALSE),
+              position = control.position,
+              options = leaflet::layersControlOptions(collapsed = control.collapsed, autoZIndex = FALSE),
               overlayGroups = quickTextHTML(sort(control_vars))
             )
         }
@@ -356,7 +379,8 @@ networkMap <-
         map <-
           leaflet::addLayersControl(
             map,
-            options = leaflet::layersControlOptions(collapsed = collapse.control, autoZIndex = FALSE),
+            position = control.position,
+            options = leaflet::layersControlOptions(collapsed = control.collapsed, autoZIndex = FALSE),
             baseGroups = names(provider)
           ) %>%
           leaflet::hideGroup(group = names(provider)[[-1]])
@@ -368,6 +392,7 @@ networkMap <-
       map <-
         leaflet::addLegend(
           map,
+          position = check_legendposition(legend.position, static = FALSE),
           title = "Network",
           colors = cols$colour,
           labels = cols$network

--- a/R/network_networkMap.R
+++ b/R/network_networkMap.R
@@ -21,7 +21,6 @@
 #' "aurn")` and the "AURN" layer control group when `source = c("aurn",
 #' "saqn")`.
 #'
-#'
 #' @param source *One or more UK or European monitoring networks.*
 #'
 #'    *default:* `"aurn"`

--- a/R/polar_annulusMap.R
+++ b/R/polar_annulusMap.R
@@ -50,8 +50,12 @@ annulusMap <- function(data,
                        cols = "turbo",
                        alpha = 1,
                        key = FALSE,
-                       draw.legend = TRUE,
-                       collapse.control = FALSE,
+                       legend = TRUE,
+                       legend.position = NULL,
+                       legend.title = NULL,
+                       legend.title.autotext = TRUE,
+                       control.collapsed = FALSE,
+                       control.position = "topright",
                        d.icon = 200,
                        d.fig = 3.5,
                        static = FALSE,
@@ -208,7 +212,19 @@ annulusMap <- function(data,
       )
 
     # create colorbar if limits specified
-    if (!all(is.na(theLimits)) & draw.legend) {
+    if (!all(is.na(theLimits)) & legend) {
+      if (legend.title.autotext) {
+        textfun <- openair::quickText
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ", ")
+      legend.title <- textfun(legend.title)
+
       map <-
         map +
         ggplot2::geom_point(
@@ -220,7 +236,8 @@ annulusMap <- function(data,
           limits = theLimits,
           colours = openair::openColours(scheme = cols)
         ) +
-        ggplot2::labs(color = openair::quickText(paste(pollutant, collapse = ", ")))
+        ggplot2::labs(color = legend.title) +
+        ggplot2::theme(legend.position = legend.position)
     }
   }
 
@@ -237,19 +254,33 @@ annulusMap <- function(data,
         popup,
         label,
         split_col,
-        collapse.control
+        control.collapsed,
+        control.position
       )
 
     # add legend if limits are set
-    if (!all(is.na(theLimits)) & draw.legend) {
+    if (!all(is.na(theLimits)) & legend) {
+      if (legend.title.autotext) {
+        textfun <- quickTextHTML
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ",<br>")
+      legend.title <- textfun(legend.title)
+
       map <-
         leaflet::addLegend(
           map,
-          title = quickTextHTML(paste(pollutant, collapse = ",<br>")),
+          title = legend.title,
           pal = leaflet::colorNumeric(
             palette = openair::openColours(scheme = cols),
             domain = theLimits
           ),
+          position = legend.position,
           values = theLimits
         )
     }

--- a/R/polar_annulusMap.R
+++ b/R/polar_annulusMap.R
@@ -63,6 +63,7 @@ annulusMap <- function(data,
                        ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
+  legend.position <- check_legendposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)

--- a/R/polar_annulusMap.R
+++ b/R/polar_annulusMap.R
@@ -213,17 +213,13 @@ annulusMap <- function(data,
 
     # create colorbar if limits specified
     if (!all(is.na(theLimits)) & legend) {
-      if (legend.title.autotext) {
-        textfun <- openair::quickText
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ", ")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+        static = static,
+        legend.title.autotext = legend.title.autotext,
+        legend.title = legend.title,
+        str = paste(pollutant, collapse = ", ")
+      )
 
       map <-
         map +
@@ -260,17 +256,13 @@ annulusMap <- function(data,
 
     # add legend if limits are set
     if (!all(is.na(theLimits)) & legend) {
-      if (legend.title.autotext) {
-        textfun <- quickTextHTML
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ",<br>")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ",<br>")
+        )
 
       map <-
         leaflet::addLegend(

--- a/R/polar_annulusMap.R
+++ b/R/polar_annulusMap.R
@@ -216,11 +216,11 @@ annulusMap <- function(data,
     if (!all(is.na(theLimits)) & legend) {
       legend.title <-
         create_legend_title(
-        static = static,
-        legend.title.autotext = legend.title.autotext,
-        legend.title = legend.title,
-        str = paste(pollutant, collapse = ", ")
-      )
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ", ")
+        )
 
       map <-
         map +

--- a/R/polar_diffMap.R
+++ b/R/polar_diffMap.R
@@ -69,8 +69,12 @@ diffMap <- function(before,
                     cols = "RdBu",
                     alpha = 1,
                     key = FALSE,
-                    draw.legend = TRUE,
-                    collapse.control = FALSE,
+                    legend = TRUE,
+                    legend.position = NULL,
+                    legend.title = NULL,
+                    legend.title.autotext = TRUE,
+                    control.collapsed = FALSE,
+                    control.position = "topright",
                     d.icon = 200,
                     d.fig = 3.5,
                     static = FALSE,
@@ -233,7 +237,19 @@ diffMap <- function(before,
       )
 
     # create colorbar if limits specified
-    if (!all(is.na(theLimits)) & draw.legend) {
+    if (!all(is.na(theLimits)) & legend) {
+      if (legend.title.autotext) {
+        textfun <- openair::quickText
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ", ")
+      legend.title <- textfun(legend.title)
+
       map <-
         map +
         ggplot2::geom_point(
@@ -245,7 +261,8 @@ diffMap <- function(before,
           limits = theLimits,
           colours = openair::openColours(scheme = cols)
         ) +
-        ggplot2::labs(color = openair::quickText(paste(pollutant, collapse = ", ")))
+        ggplot2::labs(color = legend.title) +
+        ggplot2::theme(legend.position = legend.position)
     }
   }
 
@@ -262,15 +279,29 @@ diffMap <- function(before,
         popup,
         label,
         split_col,
-        collapse.control
+        control.collapsed,
+        control.position
       )
 
     # add legend if limits are set
-    if (!all(is.na(theLimits)) & draw.legend) {
+    if (!all(is.na(theLimits)) & legend) {
+      if (legend.title.autotext) {
+        textfun <- quickTextHTML
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ",<br>")
+      legend.title <- textfun(legend.title)
+
       map <-
         leaflet::addLegend(
           map,
-          title = quickTextHTML(paste(pollutant, collapse = ",<br>")),
+          title = legend.title,
+          position = legend.position,
           pal = leaflet::colorNumeric(
             palette = openair::openColours(scheme = cols),
             domain = theLimits

--- a/R/polar_diffMap.R
+++ b/R/polar_diffMap.R
@@ -238,17 +238,13 @@ diffMap <- function(before,
 
     # create colorbar if limits specified
     if (!all(is.na(theLimits)) & legend) {
-      if (legend.title.autotext) {
-        textfun <- openair::quickText
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ", ")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ", ")
+        )
 
       map <-
         map +
@@ -285,17 +281,13 @@ diffMap <- function(before,
 
     # add legend if limits are set
     if (!all(is.na(theLimits)) & legend) {
-      if (legend.title.autotext) {
-        textfun <- quickTextHTML
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ",<br>")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ",<br>")
+        )
 
       map <-
         leaflet::addLegend(

--- a/R/polar_diffMap.R
+++ b/R/polar_diffMap.R
@@ -82,6 +82,7 @@ diffMap <- function(before,
                     ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
+  legend.position <- check_legendposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)

--- a/R/polar_freqMap.R
+++ b/R/polar_freqMap.R
@@ -245,17 +245,13 @@ freqMap <- function(data,
         dplyr::distinct(plots_df, .data[[longitude]], .data[[latitude]]) %>%
         tidyr::crossing(intervals)
 
-      if (legend.title.autotext) {
-        textfun <- openair::quickText
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(lab, collapse = ", ")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(lab, collapse = ", ")
+        )
 
       map <-
         map +
@@ -292,17 +288,13 @@ freqMap <- function(data,
 
     # add legends if breaks are set
     if (!all(is.na(theBreaks)) & legend) {
-      if (legend.title.autotext) {
-        textfun <- quickTextHTML
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(lab, collapse = ",<br>")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(lab, collapse = ",<br>")
+        )
 
       map <-
         leaflet::addLegend(

--- a/R/polar_freqMap.R
+++ b/R/polar_freqMap.R
@@ -73,8 +73,12 @@ freqMap <- function(data,
                     cols = "turbo",
                     alpha = 1,
                     key = FALSE,
-                    draw.legend = TRUE,
-                    collapse.control = FALSE,
+                    legend = TRUE,
+                    legend.position = NULL,
+                    legend.title = NULL,
+                    legend.title.autotext = TRUE,
+                    control.collapsed = FALSE,
+                    control.position = "topright",
                     d.icon = 200,
                     d.fig = 3.5,
                     static = FALSE,
@@ -227,7 +231,7 @@ freqMap <- function(data,
       )
 
     # create legend
-    if (!all(is.na(theBreaks)) & draw.legend) {
+    if (!all(is.na(theBreaks)) & legend) {
       intervals <-
         stringr::str_c(theBreaks, dplyr::lead(theBreaks), sep = " - ")
       intervals <- intervals[!is.na(intervals)]
@@ -241,6 +245,18 @@ freqMap <- function(data,
         dplyr::distinct(plots_df, .data[[longitude]], .data[[latitude]]) %>%
         tidyr::crossing(intervals)
 
+      if (legend.title.autotext) {
+        textfun <- openair::quickText
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(lab, collapse = ", ")
+      legend.title <- textfun(legend.title)
+
       map <-
         map +
         ggplot2::geom_point(
@@ -252,7 +268,8 @@ freqMap <- function(data,
           key_glyph = ggplot2::draw_key_rect
         ) +
         ggplot2::scale_fill_manual(values = pal, drop = FALSE) +
-        ggplot2::labs(fill = openair::quickText(paste(lab, collapse = ", ")))
+        ggplot2::labs(fill = legend.title) +
+        ggplot2::theme(legend.position = legend.position)
     }
   }
 
@@ -269,26 +286,35 @@ freqMap <- function(data,
         popup,
         label,
         split_col,
-        collapse.control
+        control.collapsed,
+        control.position
       )
 
     # add legends if breaks are set
-    if (!all(is.na(theBreaks)) & draw.legend) {
-      if (statistic == "frequency") {
-        title <- "Frequency"
+    if (!all(is.na(theBreaks)) & legend) {
+      if (legend.title.autotext) {
+        textfun <- quickTextHTML
       } else {
-        title <- quickTextHTML(paste(pollutant, collapse = ", "))
+        textfun <- function(x) {
+          return(x)
+        }
       }
+
+      legend.title <-
+        legend.title %||% paste(lab, collapse = ",<br>")
+      legend.title <- textfun(legend.title)
+
       map <-
         leaflet::addLegend(
           map,
+          position = legend.position,
           pal = leaflet::colorBin(
             palette = openair::openColours(scheme = cols),
             domain = theBreaks,
             bins = theBreaks
           ),
           values = theBreaks,
-          title = title
+          title = legend.title
         )
     }
   }

--- a/R/polar_freqMap.R
+++ b/R/polar_freqMap.R
@@ -86,6 +86,7 @@ freqMap <- function(data,
                     ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
+  legend.position <- check_legendposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)

--- a/R/polar_percentileMap.R
+++ b/R/polar_percentileMap.R
@@ -59,8 +59,12 @@ percentileMap <- function(data,
                           cols = "turbo",
                           alpha = 1,
                           key = FALSE,
-                          draw.legend = TRUE,
-                          collapse.control = FALSE,
+                          legend = TRUE,
+                          legend.position = NULL,
+                          legend.title = NULL,
+                          legend.title.autotext = TRUE,
+                          control.collapsed = FALSE,
+                          control.position = "topright",
                           d.icon = 200,
                           d.fig = 3.5,
                           static = FALSE,
@@ -214,7 +218,18 @@ percentileMap <- function(data,
       dplyr::distinct(plots_df, .data[[longitude]], .data[[latitude]]) %>%
       tidyr::crossing(intervals)
 
-    if (draw.legend) {
+    if (legend) {
+      if (legend.title.autotext) {
+        textfun <- openair::quickText
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <- legend.title %||% "Percentile"
+      legend.title <- textfun(legend.title)
+
       map <-
         map +
         ggplot2::geom_point(
@@ -226,7 +241,8 @@ percentileMap <- function(data,
           key_glyph = ggplot2::draw_key_rect
         ) +
         ggplot2::scale_fill_manual(values = pal, drop = FALSE) +
-        ggplot2::labs(fill = "percentile")
+        ggplot2::labs(fill = legend.title) +
+        ggplot2::theme(legend.position = legend.position)
     }
   }
 
@@ -243,16 +259,29 @@ percentileMap <- function(data,
         popup,
         label,
         split_col,
-        collapse.control
+        control.collapsed,
+        control.position
       )
 
+    if (legend.title.autotext) {
+      textfun <- quickTextHTML
+    } else {
+      textfun <- function(x) {
+        return(x)
+      }
+    }
+
+    legend.title <- legend.title %||% "Percentile"
+    legend.title <- textfun(legend.title)
+
     # add legend
-    if (all(!is.na(percentile)) & draw.legend) {
+    if (all(!is.na(percentile)) & legend) {
       percs <- unique(c(0, percentile))
       map <-
         leaflet::addLegend(
-          title = "Percentile",
           map,
+          title = legend.title,
+          position = legend.position,
           pal = leaflet::colorBin(
             palette = openair::openColours(scheme = cols, n = length(percs)),
             bins = percs,

--- a/R/polar_percentileMap.R
+++ b/R/polar_percentileMap.R
@@ -72,6 +72,7 @@ percentileMap <- function(data,
                           ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
+  legend.position <- check_legendposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)

--- a/R/polar_percentileMap.R
+++ b/R/polar_percentileMap.R
@@ -219,16 +219,13 @@ percentileMap <- function(data,
       tidyr::crossing(intervals)
 
     if (legend) {
-      if (legend.title.autotext) {
-        textfun <- openair::quickText
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
-      legend.title <- legend.title %||% "Percentile"
-      legend.title <- textfun(legend.title)
+      legend.title <-
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = "Percentile"
+        )
 
       map <-
         map +
@@ -263,16 +260,13 @@ percentileMap <- function(data,
         control.position
       )
 
-    if (legend.title.autotext) {
-      textfun <- quickTextHTML
-    } else {
-      textfun <- function(x) {
-        return(x)
-      }
-    }
-
-    legend.title <- legend.title %||% "Percentile"
-    legend.title <- textfun(legend.title)
+    legend.title <-
+      create_legend_title(
+        static = static,
+        legend.title.autotext = legend.title.autotext,
+        legend.title = legend.title,
+        str = "Percentile"
+      )
 
     # add legend
     if (all(!is.na(percentile)) & legend) {

--- a/R/polar_polarMap.R
+++ b/R/polar_polarMap.R
@@ -216,8 +216,8 @@
 #'  *default:* `"topright"` | *scope:* dynamic
 #'
 #'   When `type != NULL`, or multiple pollutants are specified, where should the
-#'   legend be placed? One of "topleft", "topright", "bottomleft" or
-#'   "bottomright". Passed to the `position` argument of
+#'   "layer control" interface be placed? One of "topleft", "topright",
+#'   "bottomleft" or "bottomright". Passed to the `position` argument of
 #'   [leaflet::addLayersControl()].
 #'
 #' @param d.icon *The diameter of the plot on the map in pixels.*

--- a/R/polar_polarMap.R
+++ b/R/polar_polarMap.R
@@ -182,8 +182,7 @@
 #'
 #'  *default:* `NULL` | *scope:* dynamic & static
 #'
-#'   When `legend = TRUE`, where should the legend be placed? Defaults to
-#'   "topleft"
+#'   When `legend = TRUE`, where should the legend be placed?
 #'
 #'   - *Dynamic*: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the `position` argument of [leaflet::addLegend()].
 #'
@@ -194,7 +193,7 @@
 #'   *default:* `NULL` | *scope:* dynamic & static
 #'
 #'   By default, when `legend.title = NULL`, the function will attempt to
-#'   provide a sensible legend title. `legent.title` allows users to overwrite
+#'   provide a sensible legend title. `legend.title` allows users to overwrite
 #'   this - for example, to include units or other contextual information. For
 #'   *dynamic* maps, users may wish to use HTML tags to format the title.
 #'

--- a/R/polar_polarMap.R
+++ b/R/polar_polarMap.R
@@ -171,19 +171,55 @@
 #'   Draw a key for each individual marker? Potentially useful when `limits =
 #'   "free"`, but of limited use otherwise.
 #'
-#' @param draw.legend *Draw a shared legend?*
+#' @param legend *Draw a shared legend?*
 #'
 #'  *default:* `TRUE` | *scope:* dynamic & static
 #'
 #'   When all markers share the same colour scale (e.g., when `limits != "free"`
 #'   in [polarMap()]), should a shared legend be created at the side of the map?
 #'
-#' @param collapse.control *Show the layer control as a collapsed?*
+#' @param legend.position *Position of the shared legend.*
+#'
+#'  *default:* `NULL` | *scope:* dynamic & static
+#'
+#'   When `legend = TRUE`, where should the legend be placed? Defaults to
+#'   "topleft"
+#'
+#'   - *Dynamic*: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the `position` argument of [leaflet::addLegend()].
+#'
+#'   - *Static:*: One of "top", "right", "bottom" or "left". Passed to the `legend.position` argument of [ggplot2::theme()].
+#'
+#' @param legend.title *Title of the legend.*
+#'
+#'   *default:* `NULL` | *scope:* dynamic & static
+#'
+#'   By default, when `legend.title = NULL`, the function will attempt to
+#'   provide a sensible legend title. `legent.title` allows users to overwrite
+#'   this - for example, to include units or other contextual information. For
+#'   *dynamic* maps, users may wish to use HTML tags to format the title.
+#'
+#' @param legend.title.autotext *Automatically format the title of the legend?*
+#'
+#'   *default:* `TRUE` | *scope:* dynamic & static
+#'
+#'   When `legend.title.autotext = TRUE`, `legend.title` will be first run
+#'   through [quickTextHTML()] (*dynamic*) or [openair::quickText()] (*static*).
+#'
+#' @param control.collapsed *Show the layer control as a collapsed?*
 #'
 #'  *default:* `FALSE` | *scope:* dynamic
 #'
 #'   For *dynamic* maps, should the "layer control" interface be collapsed? If
 #'   `TRUE`, users will have to hover over an icon to view the options.
+#'
+#' @param control.position *Position of the layer control menu*
+#'
+#'  *default:* `"topright"` | *scope:* dynamic
+#'
+#'   When `type != NULL`, or multiple pollutants are specified, where should the
+#'   legend be placed? One of "topleft", "topright", "bottomleft" or
+#'   "bottomright". Passed to the `position` argument of
+#'   [leaflet::addLayersControl()].
 #'
 #' @param d.icon *The diameter of the plot on the map in pixels.*
 #'
@@ -254,8 +290,12 @@ polarMap <- function(data,
                      cols = "turbo",
                      alpha = 1,
                      key = FALSE,
-                     draw.legend = TRUE,
-                     collapse.control = FALSE,
+                     legend = TRUE,
+                     legend.position = NULL,
+                     legend.title = NULL,
+                     legend.title.autotext = TRUE,
+                     control.collapsed = FALSE,
+                     control.position = "topright",
                      d.icon = 200,
                      d.fig = 3.5,
                      static = FALSE,
@@ -263,6 +303,7 @@ polarMap <- function(data,
                      ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
+  legend.position <- check_leafposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)
@@ -402,19 +443,33 @@ polarMap <- function(data,
         popup,
         label,
         split_col,
-        collapse.control
+        control.collapsed,
+        control.position
       )
 
     # add legend if limits are set
-    if (!all(is.na(theLimits)) & draw.legend) {
+    if (!all(is.na(theLimits)) & legend) {
+      if (legend.title.autotext) {
+        textfun <- quickTextHTML
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ",<br>")
+      legend.title <- textfun(legend.title)
+
       map <-
         leaflet::addLegend(
           map,
-          title = quickTextHTML(paste(pollutant, collapse = ",<br>")),
+          title = legend.title,
           pal = leaflet::colorNumeric(
             palette = openair::openColours(scheme = cols),
             domain = theLimits
           ),
+          position = legend.position,
           values = theLimits
         )
     }
@@ -435,7 +490,19 @@ polarMap <- function(data,
         provider = provider
       )
 
-    if (!all(is.na(theLimits)) & draw.legend) {
+    if (!all(is.na(theLimits)) & legend) {
+      if (legend.title.autotext) {
+        textfun <- openair::quickText
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ", ")
+      legend.title <- textfun(legend.title)
+
       map <-
         map +
         ggplot2::geom_point(
@@ -447,7 +514,8 @@ polarMap <- function(data,
           limits = theLimits,
           colours = openair::openColours(scheme = cols)
         ) +
-        ggplot2::labs(color = openair::quickText(paste(pollutant, collapse = ", ")))
+        ggplot2::labs(color = legend.title) +
+        ggplot2::theme(legend.position = legend.position)
     }
   }
 

--- a/R/polar_polarMap.R
+++ b/R/polar_polarMap.R
@@ -449,17 +449,13 @@ polarMap <- function(data,
 
     # add legend if limits are set
     if (!all(is.na(theLimits)) & legend) {
-      if (legend.title.autotext) {
-        textfun <- quickTextHTML
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ",<br>")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ",<br>")
+        )
 
       map <-
         leaflet::addLegend(
@@ -491,17 +487,13 @@ polarMap <- function(data,
       )
 
     if (!all(is.na(theLimits)) & legend) {
-      if (legend.title.autotext) {
-        textfun <- openair::quickText
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ", ")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ", ")
+        )
 
       map <-
         map +

--- a/R/polar_polarMap.R
+++ b/R/polar_polarMap.R
@@ -303,7 +303,7 @@ polarMap <- function(data,
                      ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
-  legend.position <- check_leafposition(legend.position, static)
+  legend.position <- check_legendposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)

--- a/R/polar_pollroseMap.R
+++ b/R/polar_pollroseMap.R
@@ -75,6 +75,7 @@ pollroseMap <- function(data,
                         ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
+  legend.position <- check_legendposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)

--- a/R/polar_pollroseMap.R
+++ b/R/polar_pollroseMap.R
@@ -196,17 +196,13 @@ pollroseMap <- function(data,
         dplyr::distinct(plots_df, .data[[longitude]], .data[[latitude]]) %>%
         tidyr::crossing(intervals)
 
-      if (legend.title.autotext) {
-        textfun <- openair::quickText
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ", ")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ", ")
+        )
 
       # add legend
       map <-
@@ -244,17 +240,13 @@ pollroseMap <- function(data,
 
     # add legend if breaks are defined
     if (!is.null(breaks) & legend) {
-      if (legend.title.autotext) {
-        textfun <- quickTextHTML
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% paste(pollutant, collapse = ",<br>")
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = paste(pollutant, collapse = ",<br>")
+        )
 
       map <-
         leaflet::addLegend(

--- a/R/polar_pollroseMap.R
+++ b/R/polar_pollroseMap.R
@@ -62,8 +62,12 @@ pollroseMap <- function(data,
                         cols = "turbo",
                         alpha = 1,
                         key = FALSE,
-                        draw.legend = TRUE,
-                        collapse.control = FALSE,
+                        legend = TRUE,
+                        legend.position = NULL,
+                        legend.title = NULL,
+                        legend.title.autotext = TRUE,
+                        control.collapsed = FALSE,
+                        control.position = "topright",
                         d.icon = 200,
                         d.fig = 3.5,
                         static = FALSE,
@@ -180,7 +184,7 @@ pollroseMap <- function(data,
       )
 
     # create legend
-    if (!is.null(breaks) & draw.legend) {
+    if (!is.null(breaks) & legend) {
       intervals <- attr(plots_df$plot[[1]]$data, "intervals")
       intervals <- factor(intervals, intervals)
       pal <-
@@ -191,6 +195,18 @@ pollroseMap <- function(data,
       dummy <-
         dplyr::distinct(plots_df, .data[[longitude]], .data[[latitude]]) %>%
         tidyr::crossing(intervals)
+
+      if (legend.title.autotext) {
+        textfun <- openair::quickText
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ", ")
+      legend.title <- textfun(legend.title)
 
       # add legend
       map <-
@@ -204,7 +220,8 @@ pollroseMap <- function(data,
           key_glyph = ggplot2::draw_key_rect
         ) +
         ggplot2::scale_fill_manual(values = pal, drop = FALSE) +
-        ggplot2::labs(fill = openair::quickText(paste(pollutant, collapse = ", ")))
+        ggplot2::labs(fill = legend.title) +
+        ggplot2::theme(legend.position = legend.position)
     }
   }
 
@@ -221,21 +238,35 @@ pollroseMap <- function(data,
         popup,
         label,
         split_col,
-        collapse.control
+        control.collapsed,
+        control.position
       )
 
     # add legend if breaks are defined
-    if (!is.null(breaks) & draw.legend) {
+    if (!is.null(breaks) & legend) {
+      if (legend.title.autotext) {
+        textfun <- quickTextHTML
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% paste(pollutant, collapse = ",<br>")
+      legend.title <- textfun(legend.title)
+
       map <-
         leaflet::addLegend(
           map,
+          position = legend.position,
           pal = leaflet::colorBin(
             palette = openair::openColours(cols),
             domain = theBreaks,
             bins = theBreaks
           ),
           values = theBreaks,
-          title = quickTextHTML(paste(pollutant, collapse = ", "))
+          title = legend.title
         )
     }
   }

--- a/R/polar_windroseMap.R
+++ b/R/polar_windroseMap.R
@@ -66,8 +66,12 @@ windroseMap <- function(data,
                         cols = "turbo",
                         alpha = 1,
                         key = FALSE,
-                        draw.legend = TRUE,
-                        collapse.control = FALSE,
+                        legend = TRUE,
+                        legend.position = NULL,
+                        legend.title = NULL,
+                        legend.title.autotext = TRUE,
+                        control.collapsed = FALSE,
+                        control.position = "topright",
                         d.icon = 200,
                         d.fig = 3.5,
                         static = FALSE,
@@ -185,7 +189,7 @@ windroseMap <- function(data,
         provider = provider
       )
 
-    if (draw.legend) {
+    if (legend) {
       # sort out legend
       intervals <- attr(plots_df$plot[[1]]$data, "intervals")
       intervals <- factor(intervals, intervals)
@@ -196,6 +200,18 @@ windroseMap <- function(data,
       dummy <-
         dplyr::distinct(plots_df, .data[[longitude]], .data[[latitude]]) %>%
         tidyr::crossing(intervals)
+
+      if (legend.title.autotext) {
+        textfun <- openair::quickText
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% "Wind Speed"
+      legend.title <- textfun(legend.title)
 
       # add legend
       map <-
@@ -209,7 +225,8 @@ windroseMap <- function(data,
           key_glyph = ggplot2::draw_key_rect
         ) +
         ggplot2::scale_fill_manual(values = pal, drop = FALSE) +
-        ggplot2::labs(fill = openair::quickText("ws"))
+        ggplot2::labs(fill = legend.title) +
+        ggplot2::theme(legend.position = legend.position)
     }
 
     return(map)
@@ -228,21 +245,35 @@ windroseMap <- function(data,
         popup,
         label,
         split_col,
-        collapse.control
+        control.collapsed,
+        control.position
       )
 
     # add legend
-    if (draw.legend) {
+    if (legend) {
+      if (legend.title.autotext) {
+        textfun <- quickTextHTML
+      } else {
+        textfun <- function(x) {
+          return(x)
+        }
+      }
+
+      legend.title <-
+        legend.title %||% "Wind Speed"
+      legend.title <- textfun(legend.title)
+
       map <-
         leaflet::addLegend(
           map,
+          position = legend.position,
           pal = leaflet::colorBin(
             palette = openair::openColours(cols),
             domain = breaks,
             bins = breaks
           ),
           values = breaks,
-          title = "Wind Speed"
+          title = legend.title
         )
     }
   }

--- a/R/polar_windroseMap.R
+++ b/R/polar_windroseMap.R
@@ -79,6 +79,7 @@ windroseMap <- function(data,
                         ...) {
   # check basemap providers are valid
   provider <- check_providers(provider, static)
+  legend.position <- check_legendposition(legend.position, static)
 
   # check for old facet/control opts
   type <- type %||% check_facet_control(...)

--- a/R/polar_windroseMap.R
+++ b/R/polar_windroseMap.R
@@ -201,17 +201,13 @@ windroseMap <- function(data,
         dplyr::distinct(plots_df, .data[[longitude]], .data[[latitude]]) %>%
         tidyr::crossing(intervals)
 
-      if (legend.title.autotext) {
-        textfun <- openair::quickText
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% "Wind Speed"
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = "Wind Speed"
+        )
 
       # add legend
       map <-
@@ -251,17 +247,13 @@ windroseMap <- function(data,
 
     # add legend
     if (legend) {
-      if (legend.title.autotext) {
-        textfun <- quickTextHTML
-      } else {
-        textfun <- function(x) {
-          return(x)
-        }
-      }
-
       legend.title <-
-        legend.title %||% "Wind Speed"
-      legend.title <- textfun(legend.title)
+        create_legend_title(
+          static = static,
+          legend.title.autotext = legend.title.autotext,
+          legend.title = legend.title,
+          str = "Wind Speed"
+        )
 
       map <-
         leaflet::addLegend(

--- a/R/traj_trajLevelMap.R
+++ b/R/traj_trajLevelMap.R
@@ -98,8 +98,8 @@ trajLevelMap <-
     # set provider tiles
     for (i in seq(length(unique(provider)))) {
       map <- leaflet::addProviderTiles(map,
-                                       provider = unique(provider)[[i]],
-                                       group = unique(provider)[[i]]
+        provider = unique(provider)[[i]],
+        group = unique(provider)[[i]]
       )
     }
 
@@ -181,7 +181,7 @@ trajLevelMap <-
        <b>Count:</b> {gridcount}<br>
        <b>Value:</b> {signif(val, 3)}"
         ),
-       coord = stringr::str_glue("({ygrid}, {xgrid})")
+        coord = stringr::str_glue("({ygrid}, {xgrid})")
       )
 
       if (statistic %in% c("difference", "frequency")) {
@@ -230,15 +230,15 @@ trajLevelMap <-
     if (length(unique(provider)) > 1 & is.null(type)) {
       map <- leaflet::addLayersControl(map, baseGroups = unique(provider))
     } else if (length(unique(provider)) == 1 &
-               !is.null(type)) {
+      !is.null(type)) {
       map <-
         leaflet::addLayersControl(map, baseGroups = sort(unique(data[[type]])))
     } else if (length(unique(provider)) > 1 &
-               !is.null(type)) {
+      !is.null(type)) {
       map <-
         leaflet::addLayersControl(map,
-                                  overlayGroups = unique(provider),
-                                  baseGroups = sort(unique(data[[type]]))
+          overlayGroups = unique(provider),
+          baseGroups = sort(unique(data[[type]]))
         )
     }
 

--- a/R/traj_trajLevelMap.R
+++ b/R/traj_trajLevelMap.R
@@ -45,7 +45,12 @@ trajLevelMap <-
            cols = "turbo",
            alpha = .5,
            tile.border = NA,
-           provider = "OpenStreetMap") {
+           provider = "OpenStreetMap",
+           legend.position = "topright",
+           legend.title = NULL,
+           legend.title.autotext = TRUE,
+           control.collapsed = FALSE,
+           control.position = "topright") {
     # get titles/legend styles
 
     style <- leaflet::labelFormat()
@@ -79,8 +84,12 @@ trajLevelMap <-
       title <- ""
     }
     if (statistic == "sqtba") {
-      title <-
-        stringr::str_glue("SQTBA<br>{quickTextHTML(pollutant)}")
+      title <- stringr::str_glue("SQTBA<br>{pollutant}")
+    }
+
+    legend.title <- legend.title %||% title
+    if (legend.title.autotext) {
+      legend.title <- quickTextHTML(legend.title)
     }
 
     # start map
@@ -210,7 +219,8 @@ trajLevelMap <-
         group = data[[type %||% "default"]]
       ) %>%
       leaflet::addLegend(
-        title = title,
+        title = legend.title,
+        position = legend.position,
         pal = pal,
         values = data[[pollutant]],
         labFormat = style

--- a/R/traj_trajLevelMap.R
+++ b/R/traj_trajLevelMap.R
@@ -230,15 +230,15 @@ trajLevelMap <-
     if (length(unique(provider)) > 1 & is.null(type)) {
       map <- leaflet::addLayersControl(map, baseGroups = unique(provider))
     } else if (length(unique(provider)) == 1 &
-      !is.null(type)) {
+               !is.null(type)) {
       map <-
         leaflet::addLayersControl(map, baseGroups = sort(unique(data[[type]])))
     } else if (length(unique(provider)) > 1 &
-      !is.null(type)) {
+               !is.null(type)) {
       map <-
         leaflet::addLayersControl(map,
-          overlayGroups = unique(provider),
-          baseGroups = sort(unique(data[[type]]))
+                                  overlayGroups = unique(provider),
+                                  baseGroups = sort(unique(data[[type]]))
         )
     }
 

--- a/R/traj_trajLevelMap.R
+++ b/R/traj_trajLevelMap.R
@@ -98,8 +98,8 @@ trajLevelMap <-
     # set provider tiles
     for (i in seq(length(unique(provider)))) {
       map <- leaflet::addProviderTiles(map,
-        provider = unique(provider)[[i]],
-        group = unique(provider)[[i]]
+                                       provider = unique(provider)[[i]],
+                                       group = unique(provider)[[i]]
       )
     }
 

--- a/R/traj_trajMap.R
+++ b/R/traj_trajMap.R
@@ -139,9 +139,11 @@ trajMap <-
            control = NULL) {
     # handle deprecated argument
     if (!is.null(control)) {
-      lifecycle::deprecate_soft(when = "0.9.0",
-                                what = "trajMap(control)",
-                                with = "trajMap(type)")
+      lifecycle::deprecate_soft(
+        when = "0.9.0",
+        what = "trajMap(control)",
+        with = "trajMap(type)"
+      )
     }
     type <- type %||% control
 
@@ -169,7 +171,7 @@ trajMap <-
         data <- dplyr::arrange(data, .data$datef)
 
         if ("factor" %in% class(data[[colour]]) |
-            "character" %in% class(data[[colour]])) {
+          "character" %in% class(data[[colour]])) {
           pal <- leaflet::colorFactor(
             palette = openair::openColours(scheme = cols, n = length(unique(data[[colour]]))),
             domain = data[[colour]]
@@ -180,8 +182,10 @@ trajMap <-
             domain = as.numeric(data[[colour]], origin = "1964-10-22")
           )
         } else {
-          pal <- leaflet::colorNumeric(palette = openair::openColours(scheme = cols),
-                                       domain = data[[colour]])
+          pal <- leaflet::colorNumeric(
+            palette = openair::openColours(scheme = cols),
+            domain = data[[colour]]
+          )
         }
       } else {
         fixedcol <- colour
@@ -201,10 +205,11 @@ trajMap <-
 
     if (!is.null(colour)) {
       if (colour %in% names(data) &
-          !colour %in% c("date", "date2", "lat", "lon", "height", "pressure")) {
+        !colour %in% c("date", "date2", "lat", "lon", "height", "pressure")) {
         data$lab <- paste(data$lab,
-                          paste0("<b>", quickTextHTML(colour), ":</b> ", data[[colour]]),
-                          sep = "<br>")
+          paste0("<b>", quickTextHTML(colour), ":</b> ", data[[colour]]),
+          sep = "<br>"
+        )
       }
     }
 
@@ -275,8 +280,9 @@ trajMap <-
               pal = pal,
               values = as.numeric(data[[colour]], origin = "1964-10-22"),
               labFormat = leaflet::labelFormat(
-                transform = function(x)
+                transform = function(x) {
                   as.Date.POSIXct(x, origin = "1964-10-22")
+                }
               )
             )
         } else {

--- a/R/traj_trajMap.R
+++ b/R/traj_trajMap.R
@@ -484,12 +484,16 @@ trajMapStatic <-
     }
 
     if (is.null(xlim)) {
-      d_lon <- diff(range(c(min(data[[longitude]]), max(data[[longitude]])))) * 0.1
-      xlim <- c(min(data[[longitude]]) - d_lon, max(data[[longitude]]) + d_lon)
+      d_lon <-
+        diff(range(c(min(data[[longitude]]), max(data[[longitude]])))) * 0.1
+      xlim <-
+        c(min(data[[longitude]]) - d_lon, max(data[[longitude]]) + d_lon)
     }
     if (is.null(ylim)) {
-      d_lat <- diff(range(c(min(data[[latitude]]), max(data[[latitude]])))) * 0.1
-      ylim <- c(min(data[[latitude]]) - d_lat, max(data[[latitude]]) + d_lat)
+      d_lat <-
+        diff(range(c(min(data[[latitude]]), max(data[[latitude]])))) * 0.1
+      ylim <-
+        c(min(data[[latitude]]) - d_lat, max(data[[latitude]]) + d_lat)
     }
 
     points_df <- dplyr::filter(data, .data$hour.inc %% npoints == 0)

--- a/R/traj_trajMap.R
+++ b/R/traj_trajMap.R
@@ -104,9 +104,9 @@
 #'
 #'  *default:* `"topright"`
 #'
-#'   Where should the legend be placed? One of "topleft", "topright",
-#'   "bottomleft" or "bottomright". Passed to the `position` argument of
-#'   [leaflet::addLayersControl()].
+#'   Where should the "layer control" interface be placed? One of "topleft",
+#'   "topright", "bottomleft" or "bottomright". Passed to the `position`
+#'   argument of [leaflet::addLayersControl()].
 #'
 #' @param control Deprecated. Please use `type`.
 #'

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -231,7 +231,7 @@ buildPopup <-
 #' @source <https://postcodes.io/>
 convertPostcode <- function(postcode) {
   if (!requireNamespace("httr", quietly = TRUE) |
-      !requireNamespace("jsonlite", quietly = TRUE)) {
+    !requireNamespace("jsonlite", quietly = TRUE)) {
     cli::cli_abort(
       c(
         "x" = "Please install the {.pkg httr} and {.pkg jsonlite} packages to use {.fun convertPostcode}.",

--- a/R/utils-map.R
+++ b/R/utils-map.R
@@ -84,7 +84,7 @@ checkMapPrep <-
       if (wd %in% Names & is.numeric(mydata[, wd])) {
         ## check for wd <0 or > 360
         if (any(sign(mydata[[wd]][!is.na(mydata[[wd]])]) == -1 |
-                mydata[[wd]][!is.na(mydata[[wd]])] > 360)) {
+          mydata[[wd]][!is.na(mydata[[wd]])] > 360)) {
           warning("Wind direction < 0 or > 360; removing these data")
           mydata[[wd]][mydata[[wd]] < 0] <- NA
           mydata[[wd]][mydata[[wd]] > 360] <- NA
@@ -234,7 +234,7 @@ assume_latlon <- function(data, latitude, longitude) {
     len <- length(out)
     if (len > 1) {
       cli::cli_abort("Cannot identify {name}: Multiple possible matches ({out})",
-                     call = NULL
+        call = NULL
       )
       return(NULL)
     } else if (len == 0) {
@@ -305,8 +305,7 @@ make_leaflet_map <-
            label,
            split_col,
            control.collapsed,
-           control.position
-  ) {
+           control.position) {
     data <- sf::st_as_sf(data, coords = c(longitude, latitude), crs = crs) %>%
       sf::st_transform(crs = 4326)
 
@@ -319,8 +318,8 @@ make_leaflet_map <-
     }
     for (i in seq_along(provider)) {
       map <- leaflet::addProviderTiles(map,
-                                       provider[[i]],
-                                       group = names(provider)[[i]]
+        provider[[i]],
+        group = names(provider)[[i]]
       )
     }
 
@@ -450,9 +449,11 @@ create_polar_markers <-
     # check for popup issues
     if (nrow(nested_df) > valid_rows) {
       cli::cli_abort(
-        c("x" = "Multiple popups/labels per {.code latitude}/{.code longitude}/{.code control} combination.",
+        c(
+          "x" = "Multiple popups/labels per {.code latitude}/{.code longitude}/{.code control} combination.",
           "i" = "Have you used a numeric column, e.g., a pollutant concentration?",
-          "i" = "Consider using {.fun buildPopup} to easily create distinct popups per marker.")
+          "i" = "Consider using {.fun buildPopup} to easily create distinct popups per marker."
+        )
       )
     }
 
@@ -484,27 +485,29 @@ create_polar_markers <-
       height <- d.fig[[2]]
     }
 
-    purrr::pwalk(list(
-      plots_df[[latitude]],
-      plots_df[[longitude]],
-      rm_illegal_chars(plots_df[[split_col]]),
-      plots_df$plot
-    ),
-    .f = ~ {
-      grDevices::png(
-        filename = paste0(dir, "/", ..1, "_", ..2, "_", ..3, "_", id, ".png"),
-        width = width * 300,
-        height = height * 300,
-        res = 300,
-        bg = "transparent",
-        type = "cairo",
-        antialias = "none"
-      )
+    purrr::pwalk(
+      list(
+        plots_df[[latitude]],
+        plots_df[[longitude]],
+        rm_illegal_chars(plots_df[[split_col]]),
+        plots_df$plot
+      ),
+      .f = ~ {
+        grDevices::png(
+          filename = paste0(dir, "/", ..1, "_", ..2, "_", ..3, "_", id, ".png"),
+          width = width * 300,
+          height = height * 300,
+          res = 300,
+          bg = "transparent",
+          type = "cairo",
+          antialias = "none"
+        )
 
-      plot(..4)
+        plot(..4)
 
-      grDevices::dev.off()
-    })
+        grDevices::dev.off()
+      }
+    )
 
     return(plots_df)
   }
@@ -587,7 +590,7 @@ create_static_map <-
       ggplot2::labs(x = NULL, y = NULL)
 
     if (length(pollutant) > 1 |
-        !is.null(facet)) {
+      !is.null(facet)) {
       plt <-
         plt + ggplot2::facet_wrap(ggplot2::vars(.data[[split_col]]), nrow = facet.nrow) +
         ggplot2::theme(strip.text = ggtext::element_markdown())
@@ -707,8 +710,9 @@ check_legendposition <- function(position, static) {
   } else {
     position <- position %||% "topright"
     rlang::arg_match(position,
-                     c("topright", "topleft", "bottomright", "bottomleft"),
-                     multiple = TRUE)
+      c("topright", "topleft", "bottomright", "bottomleft"),
+      multiple = TRUE
+    )
   }
   return(position)
 }
@@ -775,4 +779,3 @@ create_legend_title <- function(static,
   legend.title <- textfun(legend.title)
   return(legend.title)
 }
-

--- a/R/utils-map.R
+++ b/R/utils-map.R
@@ -306,7 +306,7 @@ make_leaflet_map <-
            split_col,
            control.collapsed,
            control.position
-           ) {
+  ) {
     data <- sf::st_as_sf(data, coords = c(longitude, latitude), crs = crs) %>%
       sf::st_transform(crs = 4326)
 
@@ -751,3 +751,26 @@ rm_illegal_chars <- function(x) {
 
   return(x)
 }
+
+#' Create a legend title
+#' @noRd
+create_legend_title <- function(static,
+                                legend.title.autotext,
+                                legend.title,
+                                str) {
+  if (legend.title.autotext) {
+    textfun <- quickTextHTML
+    if (static) {
+      textfun <- openair::quickText
+    }
+  } else {
+    textfun <- function(x) {
+      return(x)
+    }
+  }
+
+  legend.title <- legend.title %||% str
+  legend.title <- textfun(legend.title)
+  return(legend.title)
+}
+

--- a/R/utils-map.R
+++ b/R/utils-map.R
@@ -700,7 +700,9 @@ check_providers <- function(provider, static) {
 #' @noRd
 check_legendposition <- function(position, static) {
   if (static) {
-    position <- position %||% "right"
+    settheme <- ggplot2::theme_get()
+    setposition <- settheme$legend.position %||% "right"
+    position <- position %||% setposition
     rlang::arg_match(position, c("top", "right", "bottom", "left"), multiple = FALSE)
   } else {
     position <- position %||% "topright"

--- a/R/utils-map.R
+++ b/R/utils-map.R
@@ -698,7 +698,7 @@ check_providers <- function(provider, static) {
 
 #' Check legend positions are valid
 #' @noRd
-check_leafposition <- function(position, static) {
+check_legendposition <- function(position, static) {
   if (static) {
     position <- position %||% "right"
     rlang::arg_match(position, c("top", "right", "bottom", "left"), multiple = FALSE)

--- a/data-raw/generate-readme-fig.R
+++ b/data-raw/generate-readme-fig.R
@@ -1,4 +1,3 @@
-
 library(webshot2)
 
 devtools::load_all()
@@ -17,9 +16,10 @@ htmlwidgets::saveWidget(polar, "polardata.html")
 webshot("polardata.html", file = "polar.png")
 
 traj <- trajMap(traj_data,
-                colour = "pm10",
-                provider = "CartoDB.DarkMatter",
-                cols = "turbo")
+  colour = "pm10",
+  provider = "CartoDB.DarkMatter",
+  cols = "turbo"
+)
 
 htmlwidgets::saveWidget(traj, "trajdata.html")
 

--- a/man/annulusMap.Rd
+++ b/man/annulusMap.Rd
@@ -176,8 +176,7 @@ in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at th
 
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
-When \code{legend = TRUE}, where should the legend be placed? Defaults to
-"topleft"
+When \code{legend = TRUE}, where should the legend be placed?
 \itemize{
 \item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
 \item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
@@ -188,7 +187,7 @@ When \code{legend = TRUE}, where should the legend be placed? Defaults to
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
 By default, when \code{legend.title = NULL}, the function will attempt to
-provide a sensible legend title. \code{legent.title} allows users to overwrite
+provide a sensible legend title. \code{legend.title} allows users to overwrite
 this - for example, to include units or other contextual information. For
 \emph{dynamic} maps, users may wish to use HTML tags to format the title.}
 

--- a/man/annulusMap.Rd
+++ b/man/annulusMap.Rd
@@ -19,8 +19,12 @@ annulusMap(
   cols = "turbo",
   alpha = 1,
   key = FALSE,
-  draw.legend = TRUE,
-  collapse.control = FALSE,
+  legend = TRUE,
+  legend.position = NULL,
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   d.icon = 200,
   d.fig = 3.5,
   static = FALSE,
@@ -161,19 +165,55 @@ A value between 0 (fully transparent) and 1 (fully opaque).}
 
 Draw a key for each individual marker? Potentially useful when \code{limits = "free"}, but of limited use otherwise.}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 
 When all markers share the same colour scale (e.g., when \code{limits != "free"}
 in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+When \code{legend = TRUE}, where should the legend be placed? Defaults to
+"topleft"
+\itemize{
+\item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
+\item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
+}}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title. \code{legent.title} allows users to overwrite
+this - for example, to include units or other contextual information. For
+\emph{dynamic} maps, users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}} (\emph{dynamic}) or \code{\link[openair:quickText]{openair::quickText()}} (\emph{static}).}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE} | \emph{scope:} dynamic
 
 For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \code{TRUE}, users will have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"} | \emph{scope:} dynamic
+
+When \code{type != NULL}, or multiple pollutants are specified, where should the
+legend be placed? One of "topleft", "topright", "bottomleft" or
+"bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}
 

--- a/man/annulusMap.Rd
+++ b/man/annulusMap.Rd
@@ -210,8 +210,8 @@ For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \emph{default:} \code{"topright"} | \emph{scope:} dynamic
 
 When \code{type != NULL}, or multiple pollutants are specified, where should the
-legend be placed? One of "topleft", "topright", "bottomleft" or
-"bottomright". Passed to the \code{position} argument of
+"layer control" interface be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
 \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}

--- a/man/diffMap.Rd
+++ b/man/diffMap.Rd
@@ -202,8 +202,8 @@ For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \emph{default:} \code{"topright"} | \emph{scope:} dynamic
 
 When \code{type != NULL}, or multiple pollutants are specified, where should the
-legend be placed? One of "topleft", "topright", "bottomleft" or
-"bottomright". Passed to the \code{position} argument of
+"layer control" interface be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
 \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}

--- a/man/diffMap.Rd
+++ b/man/diffMap.Rd
@@ -168,8 +168,7 @@ in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at th
 
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
-When \code{legend = TRUE}, where should the legend be placed? Defaults to
-"topleft"
+When \code{legend = TRUE}, where should the legend be placed?
 \itemize{
 \item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
 \item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
@@ -180,7 +179,7 @@ When \code{legend = TRUE}, where should the legend be placed? Defaults to
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
 By default, when \code{legend.title = NULL}, the function will attempt to
-provide a sensible legend title. \code{legent.title} allows users to overwrite
+provide a sensible legend title. \code{legend.title} allows users to overwrite
 this - for example, to include units or other contextual information. For
 \emph{dynamic} maps, users may wish to use HTML tags to format the title.}
 

--- a/man/diffMap.Rd
+++ b/man/diffMap.Rd
@@ -20,8 +20,12 @@ diffMap(
   cols = "RdBu",
   alpha = 1,
   key = FALSE,
-  draw.legend = TRUE,
-  collapse.control = FALSE,
+  legend = TRUE,
+  legend.position = NULL,
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   d.icon = 200,
   d.fig = 3.5,
   static = FALSE,
@@ -153,19 +157,55 @@ A value between 0 (fully transparent) and 1 (fully opaque).}
 
 Draw a key for each individual marker? Potentially useful when \code{limits = "free"}, but of limited use otherwise.}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 
 When all markers share the same colour scale (e.g., when \code{limits != "free"}
 in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+When \code{legend = TRUE}, where should the legend be placed? Defaults to
+"topleft"
+\itemize{
+\item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
+\item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
+}}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title. \code{legent.title} allows users to overwrite
+this - for example, to include units or other contextual information. For
+\emph{dynamic} maps, users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}} (\emph{dynamic}) or \code{\link[openair:quickText]{openair::quickText()}} (\emph{static}).}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE} | \emph{scope:} dynamic
 
 For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \code{TRUE}, users will have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"} | \emph{scope:} dynamic
+
+When \code{type != NULL}, or multiple pollutants are specified, where should the
+legend be placed? One of "topleft", "topright", "bottomleft" or
+"bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}
 

--- a/man/freqMap.Rd
+++ b/man/freqMap.Rd
@@ -19,8 +19,12 @@ freqMap(
   cols = "turbo",
   alpha = 1,
   key = FALSE,
-  draw.legend = TRUE,
-  collapse.control = FALSE,
+  legend = TRUE,
+  legend.position = NULL,
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   d.icon = 200,
   d.fig = 3.5,
   static = FALSE,
@@ -171,19 +175,55 @@ A value between 0 (fully transparent) and 1 (fully opaque).}
 
 Draw a key for each individual marker? Potentially useful when \code{limits = "free"}, but of limited use otherwise.}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 
 When all markers share the same colour scale (e.g., when \code{limits != "free"}
 in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+When \code{legend = TRUE}, where should the legend be placed? Defaults to
+"topleft"
+\itemize{
+\item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
+\item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
+}}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title. \code{legent.title} allows users to overwrite
+this - for example, to include units or other contextual information. For
+\emph{dynamic} maps, users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}} (\emph{dynamic}) or \code{\link[openair:quickText]{openair::quickText()}} (\emph{static}).}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE} | \emph{scope:} dynamic
 
 For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \code{TRUE}, users will have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"} | \emph{scope:} dynamic
+
+When \code{type != NULL}, or multiple pollutants are specified, where should the
+legend be placed? One of "topleft", "topright", "bottomleft" or
+"bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}
 

--- a/man/freqMap.Rd
+++ b/man/freqMap.Rd
@@ -220,8 +220,8 @@ For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \emph{default:} \code{"topright"} | \emph{scope:} dynamic
 
 When \code{type != NULL}, or multiple pollutants are specified, where should the
-legend be placed? One of "topleft", "topright", "bottomleft" or
-"bottomright". Passed to the \code{position} argument of
+"layer control" interface be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
 \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}

--- a/man/freqMap.Rd
+++ b/man/freqMap.Rd
@@ -186,8 +186,7 @@ in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at th
 
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
-When \code{legend = TRUE}, where should the legend be placed? Defaults to
-"topleft"
+When \code{legend = TRUE}, where should the legend be placed?
 \itemize{
 \item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
 \item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
@@ -198,7 +197,7 @@ When \code{legend = TRUE}, where should the legend be placed? Defaults to
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
 By default, when \code{legend.title = NULL}, the function will attempt to
-provide a sensible legend title. \code{legent.title} allows users to overwrite
+provide a sensible legend title. \code{legend.title} allows users to overwrite
 this - for example, to include units or other contextual information. For
 \emph{dynamic} maps, users may wish to use HTML tags to format the title.}
 

--- a/man/networkMap.Rd
+++ b/man/networkMap.Rd
@@ -61,7 +61,7 @@ over a range of years. See \code{\link[openair:importMeta]{openair::importMeta()
 
 \item{cluster}{\emph{Cluster markers together when zoomed out?}
 
-\emph{default:} \code{FALSE}
+\emph{default:} \code{TRUE}
 
 When \code{cluster = TRUE}, markers are clustered together. This may be useful
 for sources like "kcl" where there are many markers very close together.
@@ -81,14 +81,14 @@ own using a named vector (e.g., \code{c("Default" = "OpenStreetMap", "Satellite"
 
 \item{legend}{\emph{Draw a shared legend?}
 
-\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+\emph{default:} \code{TRUE}
 
 When multiple \code{source}s are defined, should a shared legend be created at
 the side of the map?}
 
 \item{collapse.control}{\emph{Show the layer control as a collapsed?}
 
-\emph{default:} \code{FALSE} | \emph{scope:} dynamic
+\emph{default:} \code{FALSE}
 
 Should the "layer control" interface be collapsed? If \code{TRUE}, users will
 have to hover over an icon to view the options.}

--- a/man/networkMap.Rd
+++ b/man/networkMap.Rd
@@ -11,7 +11,9 @@ networkMap(
   cluster = TRUE,
   provider = c(Default = "OpenStreetMap", Satellite = "Esri.WorldImagery"),
   legend = TRUE,
-  collapse.control = FALSE
+  legend.position = "topright",
+  control.collapsed = FALSE,
+  control.position = "topright"
 )
 }
 \arguments{
@@ -86,12 +88,28 @@ own using a named vector (e.g., \code{c("Default" = "OpenStreetMap", "Satellite"
 When multiple \code{source}s are defined, should a shared legend be created at
 the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the legend}
+
+\emph{default:} \code{"topright"}
+
+Where should the shared legend be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE}
 
 Should the "layer control" interface be collapsed? If \code{TRUE}, users will
 have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"}
+
+Where should the "layer control" interface be placed? One of "topleft",
+"topright", "bottomleft" or "bottomright". Passed to the \code{position}
+argument of \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 }
 \value{
 A leaflet object.

--- a/man/networkMap.Rd
+++ b/man/networkMap.Rd
@@ -10,7 +10,7 @@ networkMap(
   year = NULL,
   cluster = TRUE,
   provider = c(Default = "OpenStreetMap", Satellite = "Esri.WorldImagery"),
-  draw.legend = TRUE,
+  legend = TRUE,
   collapse.control = FALSE
 )
 }
@@ -79,7 +79,7 @@ can be toggled between using a "layer control" interface. By default, the
 interface will use the provider names as labels, but users can define their
 own using a named vector (e.g., \code{c("Default" = "OpenStreetMap", "Satellite" = "Esri.WorldImagery")})}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 

--- a/man/percentileMap.Rd
+++ b/man/percentileMap.Rd
@@ -207,8 +207,8 @@ For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \emph{default:} \code{"topright"} | \emph{scope:} dynamic
 
 When \code{type != NULL}, or multiple pollutants are specified, where should the
-legend be placed? One of "topleft", "topright", "bottomleft" or
-"bottomright". Passed to the \code{position} argument of
+"layer control" interface be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
 \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}

--- a/man/percentileMap.Rd
+++ b/man/percentileMap.Rd
@@ -173,8 +173,7 @@ in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at th
 
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
-When \code{legend = TRUE}, where should the legend be placed? Defaults to
-"topleft"
+When \code{legend = TRUE}, where should the legend be placed?
 \itemize{
 \item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
 \item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
@@ -185,7 +184,7 @@ When \code{legend = TRUE}, where should the legend be placed? Defaults to
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
 By default, when \code{legend.title = NULL}, the function will attempt to
-provide a sensible legend title. \code{legent.title} allows users to overwrite
+provide a sensible legend title. \code{legend.title} allows users to overwrite
 this - for example, to include units or other contextual information. For
 \emph{dynamic} maps, users may wish to use HTML tags to format the title.}
 

--- a/man/percentileMap.Rd
+++ b/man/percentileMap.Rd
@@ -19,8 +19,12 @@ percentileMap(
   cols = "turbo",
   alpha = 1,
   key = FALSE,
-  draw.legend = TRUE,
-  collapse.control = FALSE,
+  legend = TRUE,
+  legend.position = NULL,
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   d.icon = 200,
   d.fig = 3.5,
   static = FALSE,
@@ -158,19 +162,55 @@ A value between 0 (fully transparent) and 1 (fully opaque).}
 
 Draw a key for each individual marker? Potentially useful when \code{limits = "free"}, but of limited use otherwise.}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 
 When all markers share the same colour scale (e.g., when \code{limits != "free"}
 in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+When \code{legend = TRUE}, where should the legend be placed? Defaults to
+"topleft"
+\itemize{
+\item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
+\item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
+}}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title. \code{legent.title} allows users to overwrite
+this - for example, to include units or other contextual information. For
+\emph{dynamic} maps, users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}} (\emph{dynamic}) or \code{\link[openair:quickText]{openair::quickText()}} (\emph{static}).}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE} | \emph{scope:} dynamic
 
 For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \code{TRUE}, users will have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"} | \emph{scope:} dynamic
+
+When \code{type != NULL}, or multiple pollutants are specified, where should the
+legend be placed? One of "topleft", "topright", "bottomleft" or
+"bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}
 

--- a/man/polarMap.Rd
+++ b/man/polarMap.Rd
@@ -189,8 +189,7 @@ in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at th
 
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
-When \code{legend = TRUE}, where should the legend be placed? Defaults to
-"topleft"
+When \code{legend = TRUE}, where should the legend be placed?
 \itemize{
 \item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
 \item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
@@ -201,7 +200,7 @@ When \code{legend = TRUE}, where should the legend be placed? Defaults to
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
 By default, when \code{legend.title = NULL}, the function will attempt to
-provide a sensible legend title. \code{legent.title} allows users to overwrite
+provide a sensible legend title. \code{legend.title} allows users to overwrite
 this - for example, to include units or other contextual information. For
 \emph{dynamic} maps, users may wish to use HTML tags to format the title.}
 

--- a/man/polarMap.Rd
+++ b/man/polarMap.Rd
@@ -20,8 +20,12 @@ polarMap(
   cols = "turbo",
   alpha = 1,
   key = FALSE,
-  draw.legend = TRUE,
-  collapse.control = FALSE,
+  legend = TRUE,
+  legend.position = NULL,
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   d.icon = 200,
   d.fig = 3.5,
   static = FALSE,
@@ -174,19 +178,55 @@ A value between 0 (fully transparent) and 1 (fully opaque).}
 
 Draw a key for each individual marker? Potentially useful when \code{limits = "free"}, but of limited use otherwise.}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 
 When all markers share the same colour scale (e.g., when \code{limits != "free"}
 in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+When \code{legend = TRUE}, where should the legend be placed? Defaults to
+"topleft"
+\itemize{
+\item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
+\item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
+}}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title. \code{legent.title} allows users to overwrite
+this - for example, to include units or other contextual information. For
+\emph{dynamic} maps, users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}} (\emph{dynamic}) or \code{\link[openair:quickText]{openair::quickText()}} (\emph{static}).}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE} | \emph{scope:} dynamic
 
 For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \code{TRUE}, users will have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"} | \emph{scope:} dynamic
+
+When \code{type != NULL}, or multiple pollutants are specified, where should the
+legend be placed? One of "topleft", "topright", "bottomleft" or
+"bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}
 

--- a/man/polarMap.Rd
+++ b/man/polarMap.Rd
@@ -223,8 +223,8 @@ For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \emph{default:} \code{"topright"} | \emph{scope:} dynamic
 
 When \code{type != NULL}, or multiple pollutants are specified, where should the
-legend be placed? One of "topleft", "topright", "bottomleft" or
-"bottomright". Passed to the \code{position} argument of
+"layer control" interface be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
 \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}

--- a/man/pollroseMap.Rd
+++ b/man/pollroseMap.Rd
@@ -175,8 +175,7 @@ in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at th
 
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
-When \code{legend = TRUE}, where should the legend be placed? Defaults to
-"topleft"
+When \code{legend = TRUE}, where should the legend be placed?
 \itemize{
 \item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
 \item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
@@ -187,7 +186,7 @@ When \code{legend = TRUE}, where should the legend be placed? Defaults to
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
 By default, when \code{legend.title = NULL}, the function will attempt to
-provide a sensible legend title. \code{legent.title} allows users to overwrite
+provide a sensible legend title. \code{legend.title} allows users to overwrite
 this - for example, to include units or other contextual information. For
 \emph{dynamic} maps, users may wish to use HTML tags to format the title.}
 

--- a/man/pollroseMap.Rd
+++ b/man/pollroseMap.Rd
@@ -19,8 +19,12 @@ pollroseMap(
   cols = "turbo",
   alpha = 1,
   key = FALSE,
-  draw.legend = TRUE,
-  collapse.control = FALSE,
+  legend = TRUE,
+  legend.position = NULL,
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   d.icon = 200,
   d.fig = 3.5,
   static = FALSE,
@@ -160,19 +164,55 @@ A value between 0 (fully transparent) and 1 (fully opaque).}
 
 Draw a key for each individual marker? Potentially useful when \code{limits = "free"}, but of limited use otherwise.}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 
 When all markers share the same colour scale (e.g., when \code{limits != "free"}
 in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+When \code{legend = TRUE}, where should the legend be placed? Defaults to
+"topleft"
+\itemize{
+\item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
+\item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
+}}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title. \code{legent.title} allows users to overwrite
+this - for example, to include units or other contextual information. For
+\emph{dynamic} maps, users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}} (\emph{dynamic}) or \code{\link[openair:quickText]{openair::quickText()}} (\emph{static}).}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE} | \emph{scope:} dynamic
 
 For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \code{TRUE}, users will have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"} | \emph{scope:} dynamic
+
+When \code{type != NULL}, or multiple pollutants are specified, where should the
+legend be placed? One of "topleft", "topright", "bottomleft" or
+"bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}
 

--- a/man/pollroseMap.Rd
+++ b/man/pollroseMap.Rd
@@ -209,8 +209,8 @@ For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \emph{default:} \code{"topright"} | \emph{scope:} dynamic
 
 When \code{type != NULL}, or multiple pollutants are specified, where should the
-legend be placed? One of "topleft", "topright", "bottomleft" or
-"bottomright". Passed to the \code{position} argument of
+"layer control" interface be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
 \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}

--- a/man/trajLevelMap.Rd
+++ b/man/trajLevelMap.Rd
@@ -158,9 +158,9 @@ have to hover over an icon to view the options.}
 
 \emph{default:} \code{"topright"}
 
-Where should the legend be placed? One of "topleft", "topright",
-"bottomleft" or "bottomright". Passed to the \code{position} argument of
-\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
+Where should the "layer control" interface be placed? One of "topleft",
+"topright", "bottomleft" or "bottomright". Passed to the \code{position}
+argument of \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 }
 \value{
 A leaflet object.

--- a/man/trajLevelMap.Rd
+++ b/man/trajLevelMap.Rd
@@ -21,7 +21,12 @@ trajLevelMap(
   cols = "turbo",
   alpha = 0.5,
   tile.border = NA,
-  provider = "OpenStreetMap"
+  provider = "OpenStreetMap",
+  legend.position = "topright",
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright"
 )
 }
 \arguments{
@@ -117,6 +122,45 @@ relatively perceptually uniform colours. Read more about this palette at
 A single \link[leaflet:providers]{leaflet::providers}. See
 \url{http://leaflet-extras.github.io/leaflet-providers/preview/} for a list of
 all base maps that can be used.}
+
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{"topright"}
+
+Where should the legend be placed? One of "topright", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLegend]{leaflet::addLegend()}}. \code{NULL} defaults to "topright".}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL}
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title based on \code{colour}. \code{legend.title} allows
+users to overwrite this - for example, to include units or other contextual
+information. Users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE}
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}}.}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
+
+\emph{default:} \code{FALSE}
+
+Should the "layer control" interface be collapsed? If \code{TRUE}, users will
+have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"}
+
+Where should the legend be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 }
 \value{
 A leaflet object.

--- a/man/trajMap.Rd
+++ b/man/trajMap.Rd
@@ -14,7 +14,11 @@ trajMap(
   alpha = 0.5,
   npoints = 12,
   provider = "OpenStreetMap",
-  collapse.control = FALSE,
+  legend.position = "topright",
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   control = NULL
 )
 }
@@ -51,7 +55,7 @@ selected between using a "layer control" menu. Passed to
 
 \item{cols}{\emph{Colours to use for plotting.}
 
-\emph{default:} \code{"turbo"}
+\emph{default:} \code{"default"}
 
 The colours used for plotting, passed to \code{\link[openair:openColours]{openair::openColours()}}.}
 
@@ -80,12 +84,44 @@ A single \link[leaflet:providers]{leaflet::providers}. See
 \url{http://leaflet-extras.github.io/leaflet-providers/preview/} for a list of
 all base maps that can be used.}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{"topright"}
+
+Where should the legend be placed? One of "topright", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLegend]{leaflet::addLegend()}}. \code{NULL} defaults to "topright".}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL}
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title based on \code{colour}. \code{legend.title} allows
+users to overwrite this - for example, to include units or other contextual
+information. Users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE}
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}}.}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE}
 
 Should the "layer control" interface be collapsed? If \code{TRUE}, users will
 have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"}
+
+Where should the legend be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{control}{Deprecated. Please use \code{type}.}
 }

--- a/man/trajMap.Rd
+++ b/man/trajMap.Rd
@@ -119,9 +119,9 @@ have to hover over an icon to view the options.}
 
 \emph{default:} \code{"topright"}
 
-Where should the legend be placed? One of "topleft", "topright",
-"bottomleft" or "bottomright". Passed to the \code{position} argument of
-\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
+Where should the "layer control" interface be placed? One of "topleft",
+"topright", "bottomleft" or "bottomright". Passed to the \code{position}
+argument of \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{control}{Deprecated. Please use \code{type}.}
 }

--- a/man/windroseMap.Rd
+++ b/man/windroseMap.Rd
@@ -155,8 +155,7 @@ in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at th
 
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
-When \code{legend = TRUE}, where should the legend be placed? Defaults to
-"topleft"
+When \code{legend = TRUE}, where should the legend be placed?
 \itemize{
 \item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
 \item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
@@ -167,7 +166,7 @@ When \code{legend = TRUE}, where should the legend be placed? Defaults to
 \emph{default:} \code{NULL} | \emph{scope:} dynamic & static
 
 By default, when \code{legend.title = NULL}, the function will attempt to
-provide a sensible legend title. \code{legent.title} allows users to overwrite
+provide a sensible legend title. \code{legend.title} allows users to overwrite
 this - for example, to include units or other contextual information. For
 \emph{dynamic} maps, users may wish to use HTML tags to format the title.}
 

--- a/man/windroseMap.Rd
+++ b/man/windroseMap.Rd
@@ -18,8 +18,12 @@ windroseMap(
   cols = "turbo",
   alpha = 1,
   key = FALSE,
-  draw.legend = TRUE,
-  collapse.control = FALSE,
+  legend = TRUE,
+  legend.position = NULL,
+  legend.title = NULL,
+  legend.title.autotext = TRUE,
+  control.collapsed = FALSE,
+  control.position = "topright",
   d.icon = 200,
   d.fig = 3.5,
   static = FALSE,
@@ -140,19 +144,55 @@ A value between 0 (fully transparent) and 1 (fully opaque).}
 
 Draw a key for each individual marker? Potentially useful when \code{limits = "free"}, but of limited use otherwise.}
 
-\item{draw.legend}{\emph{Draw a shared legend?}
+\item{legend}{\emph{Draw a shared legend?}
 
 \emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
 
 When all markers share the same colour scale (e.g., when \code{limits != "free"}
 in \code{\link[=polarMap]{polarMap()}}), should a shared legend be created at the side of the map?}
 
-\item{collapse.control}{\emph{Show the layer control as a collapsed?}
+\item{legend.position}{\emph{Position of the shared legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+When \code{legend = TRUE}, where should the legend be placed? Defaults to
+"topleft"
+\itemize{
+\item \emph{Dynamic}: One of "topright", "topright", "bottomleft" or "bottomright". Passed to the \code{position} argument of \code{\link[leaflet:addLegend]{leaflet::addLegend()}}.
+\item \emph{Static:}: One of "top", "right", "bottom" or "left". Passed to the \code{legend.position} argument of \code{\link[ggplot2:theme]{ggplot2::theme()}}.
+}}
+
+\item{legend.title}{\emph{Title of the legend.}
+
+\emph{default:} \code{NULL} | \emph{scope:} dynamic & static
+
+By default, when \code{legend.title = NULL}, the function will attempt to
+provide a sensible legend title. \code{legent.title} allows users to overwrite
+this - for example, to include units or other contextual information. For
+\emph{dynamic} maps, users may wish to use HTML tags to format the title.}
+
+\item{legend.title.autotext}{\emph{Automatically format the title of the legend?}
+
+\emph{default:} \code{TRUE} | \emph{scope:} dynamic & static
+
+When \code{legend.title.autotext = TRUE}, \code{legend.title} will be first run
+through \code{\link[=quickTextHTML]{quickTextHTML()}} (\emph{dynamic}) or \code{\link[openair:quickText]{openair::quickText()}} (\emph{static}).}
+
+\item{control.collapsed}{\emph{Show the layer control as a collapsed?}
 
 \emph{default:} \code{FALSE} | \emph{scope:} dynamic
 
 For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \code{TRUE}, users will have to hover over an icon to view the options.}
+
+\item{control.position}{\emph{Position of the layer control menu}
+
+\emph{default:} \code{"topright"} | \emph{scope:} dynamic
+
+When \code{type != NULL}, or multiple pollutants are specified, where should the
+legend be placed? One of "topleft", "topright", "bottomleft" or
+"bottomright". Passed to the \code{position} argument of
+\code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}
 

--- a/man/windroseMap.Rd
+++ b/man/windroseMap.Rd
@@ -189,8 +189,8 @@ For \emph{dynamic} maps, should the "layer control" interface be collapsed? If
 \emph{default:} \code{"topright"} | \emph{scope:} dynamic
 
 When \code{type != NULL}, or multiple pollutants are specified, where should the
-legend be placed? One of "topleft", "topright", "bottomleft" or
-"bottomright". Passed to the \code{position} argument of
+"layer control" interface be placed? One of "topleft", "topright",
+"bottomleft" or "bottomright". Passed to the \code{position} argument of
 \code{\link[leaflet:addLayersControl]{leaflet::addLayersControl()}}.}
 
 \item{d.icon}{\emph{The diameter of the plot on the map in pixels.}


### PR DESCRIPTION
I believe this solves #51, among other things.

Across almost all `{openairmaps}` functions, this PR gives users the option to:

- Control the *position* of legends and layer control menus.
- Control the *titles* of legends
- Control whether legend titles get `quickText()`-ed

This brings `{openairmaps}` closer to `{openair}`, which has arguments like `key.position` and so on. 

This is a minor breaking change as it renames some arguments.