### PR TITLE
Allow pairwise statistics in `polarMap()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openairmaps
 Title: Create Maps of Air Pollution Data
-Version: 0.9.0.9000
+Version: 0.9.0.9001
 Authors@R: c(
     person("Jack", "Davison", , "jack.davison@ricardo.com", role = c("cre", "aut")),
     person("David", "Carslaw", , "david.carslaw@york.ac.uk", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openairmaps (development version)
 
+## New features
+
+* Pairwise statistics (e.g., `"robust_slope"`) are now supported by `polarMap()`. (#72)
+
 ## Bug fixes
 
 * Vectors greater than length 1 passed to `popup` in the `polarMap()` argument will no longer error when `type = NULL`.

--- a/R/polar_polarMap.R
+++ b/R/polar_polarMap.R
@@ -44,13 +44,15 @@
 #'   **required** | *scope:* dynamic & static
 #'
 #'   The column name(s) of the pollutant(s) to plot. If multiple pollutants are
-#'   specified the `type` argument will no longer be able to be used, and:
+#'   specified and a non-pairwise statistic is supplied, the `type` argument
+#'   will no longer be able to be used and:
 #'
 #'   - *Dynamic*: The pollutants can be toggled between using a "layer control" menu.
 #'
 #'   - *Static:*: The pollutants will each appear in a different panel.
 #'
-#'   Multiple `pollutants` prohibit the use of the `type` argument.
+#'   Multiple `pollutants` prohibit the use of the `type` argument for
+#'   non-pairwise statistics.
 #'
 #' @param x *The radial axis variable.*
 #'
@@ -317,6 +319,21 @@ polarMap <- function(data,
                      static.nrow = NULL,
                      ...,
                      control = NULL) {
+  # list pairwise statistics
+  pairwise_stats <- c("r",
+                      "Pearson",
+                      "Spearman",
+                      "robust_slope",
+                      "quantile.slope",
+                      "york_slope")
+  dots <- rlang::list2(...)
+  pairwise_flag <- FALSE
+  if ("statistic" %in% names(dots)) {
+    if (dots$statistic %in% pairwise_stats) {
+      pairwise_flag <- TRUE
+    }
+  }
+
   # check basemap providers are valid
   provider <- check_providers(provider, static)
   legend.position <- check_legendposition(legend.position, static)
@@ -334,7 +351,9 @@ polarMap <- function(data,
   longitude <- latlon$longitude
 
   # auto limits
-  limits <- check_multipoll(limits, pollutant)
+  if (!pairwise_flag) {
+    limits <- check_multipoll(limits, pollutant)
+  }
 
   if ("fixed" %in% limits) {
     data <-
@@ -403,24 +422,34 @@ polarMap <- function(data,
       latitude,
       longitude,
       popup,
-      label
+      label,
+      .to_narrow = !pairwise_flag,
+      .pairwise = pairwise_flag
     )
 
   # identify splitting column (defaulting to pollutant)
-  if (length(pollutant) > 1) {
+  if (length(pollutant) > 1 && !pairwise_flag) {
     split_col <- "pollutant_name"
   } else if (!is.null(type)) {
     data[type] <- as.factor(data[[type]])
     split_col <- type
+  } else if (pairwise_flag) {
+    data$pollutant_name <- "DUMMY"
+    split_col <- "pollutant_name"
   } else {
     split_col <- "pollutant_name"
   }
 
   # define function
+  if (pairwise_flag) {
+    funpoll <- pollutant
+  } else {
+    funpoll <- "conc"
+  }
   fun <- function(data) {
     openair::polarPlot(
       data,
-      pollutant = "conc",
+      pollutant = funpoll,
       x = x,
       plot = FALSE,
       limits = theLimits,
@@ -443,7 +472,8 @@ polarMap <- function(data,
       split_col = split_col,
       d.fig = d.fig,
       popup = popup,
-      label = label
+      label = label,
+      dropcol = funpoll
     )
 
   if (!static) {

--- a/R/utils-map.R
+++ b/R/utils-map.R
@@ -182,8 +182,8 @@ prepMapData <-
     if (length(pollutant) > 1 & !is.null(control) & !.pairwise) {
       cli::cli_warn(
         c(
-          "!" = "Multiple pollutants {.emph and} {.code control/facet} option specified",
-          "i" = "Please only specify multiple pollutants {.emph or} a {.code control/facet} option",
+          "!" = "Multiple pollutants {.emph and} {.code type} option specified",
+          "i" = "Please only specify multiple pollutants {.emph or} a {.code type} option",
           "i" = "Defaulting to splitting by {.code pollutant}"
         )
       )

--- a/R/utils-map.R
+++ b/R/utils-map.R
@@ -156,7 +156,7 @@ checkMapPrep <-
 #' Prep data for mapping
 #' @noRd
 prepMapData <-
-  function(data, pollutant, control, ..., .to_narrow = TRUE) {
+  function(data, pollutant, control, ..., .to_narrow = TRUE, .pairwise = FALSE) {
     # check pollutant is there
     if (is.null(pollutant)) {
       cli::cli_abort(
@@ -179,7 +179,7 @@ prepMapData <-
     }
 
     # check if more than one pollutant & is.null split
-    if (length(pollutant) > 1 & !is.null(control)) {
+    if (length(pollutant) > 1 & !is.null(control) & !.pairwise) {
       cli::cli_warn(
         c(
           "!" = "Multiple pollutants {.emph and} {.code control/facet} option specified",

--- a/man/annulusMap.Rd
+++ b/man/annulusMap.Rd
@@ -51,13 +51,15 @@ used in conjunction with \code{crs}).}
 \strong{required} | \emph{scope:} dynamic & static
 
 The column name(s) of the pollutant(s) to plot. If multiple pollutants are
-specified the \code{type} argument will no longer be able to be used, and:
+specified and a non-pairwise statistic is supplied, the \code{type} argument
+will no longer be able to be used and:
 \itemize{
 \item \emph{Dynamic}: The pollutants can be toggled between using a "layer control" menu.
 \item \emph{Static:}: The pollutants will each appear in a different panel.
 }
 
-Multiple \code{pollutants} prohibit the use of the \code{type} argument.}
+Multiple \code{pollutants} prohibit the use of the \code{type} argument for
+non-pairwise statistics.}
 
 \item{period}{\emph{Temporal period for radial axis.}
 

--- a/man/deprecated-static-polar-maps.Rd
+++ b/man/deprecated-static-polar-maps.Rd
@@ -162,13 +162,15 @@ used in conjunction with \code{crs}).}
 \strong{required} | \emph{scope:} dynamic & static
 
 The column name(s) of the pollutant(s) to plot. If multiple pollutants are
-specified the \code{type} argument will no longer be able to be used, and:
+specified and a non-pairwise statistic is supplied, the \code{type} argument
+will no longer be able to be used and:
 \itemize{
 \item \emph{Dynamic}: The pollutants can be toggled between using a "layer control" menu.
 \item \emph{Static:}: The pollutants will each appear in a different panel.
 }
 
-Multiple \code{pollutants} prohibit the use of the \code{type} argument.}
+Multiple \code{pollutants} prohibit the use of the \code{type} argument for
+non-pairwise statistics.}
 
 \item{x}{\emph{The radial axis variable.}
 

--- a/man/freqMap.Rd
+++ b/man/freqMap.Rd
@@ -51,13 +51,15 @@ used in conjunction with \code{crs}).}
 \strong{required} | \emph{scope:} dynamic & static
 
 The column name(s) of the pollutant(s) to plot. If multiple pollutants are
-specified the \code{type} argument will no longer be able to be used, and:
+specified and a non-pairwise statistic is supplied, the \code{type} argument
+will no longer be able to be used and:
 \itemize{
 \item \emph{Dynamic}: The pollutants can be toggled between using a "layer control" menu.
 \item \emph{Static:}: The pollutants will each appear in a different panel.
 }
 
-Multiple \code{pollutants} prohibit the use of the \code{type} argument.}
+Multiple \code{pollutants} prohibit the use of the \code{type} argument for
+non-pairwise statistics.}
 
 \item{statistic}{\emph{The statistic that should be applied to each wind
 speed/direction bin.}

--- a/man/percentileMap.Rd
+++ b/man/percentileMap.Rd
@@ -51,13 +51,15 @@ used in conjunction with \code{crs}).}
 \strong{required} | \emph{scope:} dynamic & static
 
 The column name(s) of the pollutant(s) to plot. If multiple pollutants are
-specified the \code{type} argument will no longer be able to be used, and:
+specified and a non-pairwise statistic is supplied, the \code{type} argument
+will no longer be able to be used and:
 \itemize{
 \item \emph{Dynamic}: The pollutants can be toggled between using a "layer control" menu.
 \item \emph{Static:}: The pollutants will each appear in a different panel.
 }
 
-Multiple \code{pollutants} prohibit the use of the \code{type} argument.}
+Multiple \code{pollutants} prohibit the use of the \code{type} argument for
+non-pairwise statistics.}
 
 \item{percentile}{\emph{The percentile values for the colour scale bin.}
 

--- a/man/polarMap.Rd
+++ b/man/polarMap.Rd
@@ -52,13 +52,15 @@ used in conjunction with \code{crs}).}
 \strong{required} | \emph{scope:} dynamic & static
 
 The column name(s) of the pollutant(s) to plot. If multiple pollutants are
-specified the \code{type} argument will no longer be able to be used, and:
+specified and a non-pairwise statistic is supplied, the \code{type} argument
+will no longer be able to be used and:
 \itemize{
 \item \emph{Dynamic}: The pollutants can be toggled between using a "layer control" menu.
 \item \emph{Static:}: The pollutants will each appear in a different panel.
 }
 
-Multiple \code{pollutants} prohibit the use of the \code{type} argument.}
+Multiple \code{pollutants} prohibit the use of the \code{type} argument for
+non-pairwise statistics.}
 
 \item{x}{\emph{The radial axis variable.}
 

--- a/man/pollroseMap.Rd
+++ b/man/pollroseMap.Rd
@@ -51,13 +51,15 @@ used in conjunction with \code{crs}).}
 \strong{required} | \emph{scope:} dynamic & static
 
 The column name(s) of the pollutant(s) to plot. If multiple pollutants are
-specified the \code{type} argument will no longer be able to be used, and:
+specified and a non-pairwise statistic is supplied, the \code{type} argument
+will no longer be able to be used and:
 \itemize{
 \item \emph{Dynamic}: The pollutants can be toggled between using a "layer control" menu.
 \item \emph{Static:}: The pollutants will each appear in a different panel.
 }
 
-Multiple \code{pollutants} prohibit the use of the \code{type} argument.}
+Multiple \code{pollutants} prohibit the use of the \code{type} argument for
+non-pairwise statistics.}
 
 \item{statistic}{\emph{The statistic to be applied to each data bin in the plot}
 


### PR DESCRIPTION
Fixes #72 

Allows pairwise stats (e.g., "r", "Pearson", etc.).